### PR TITLE
Support for KVUrl for PAT

### DIFF
--- a/src/AzSK.ADO/ContinuousAssurance/ContinuousAssurance.ps1
+++ b/src/AzSK.ADO/ContinuousAssurance/ContinuousAssurance.ps1
@@ -58,7 +58,7 @@ function Install-AzSKADOContinuousAssurance
 
 		[Parameter(Mandatory = $false, ParameterSetName = "Default", HelpMessage = "PAT token secure string for organization to be scanned.")]
 		[ValidateNotNullOrEmpty()]
-		[Alias("pat")]
+		[Alias("pat","tkn")]
 		[System.Security.SecureString]
 		$PATToken,
 


### PR DESCRIPTION
## Description
</br>
Support for key vault URL that holds an ADO PAT token as a secret. The URL may be specified with or without version tag.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
