### PR TITLE
Area path validation api, restrict api call if area path is given in cmd & already validated, user bug not enable msg color changed to yellow

### DIFF
--- a/src/AzSK.ADO/Framework/BugLog/AutoBugLog.ps1
+++ b/src/AzSK.ADO/Framework/BugLog/AutoBugLog.ps1
@@ -87,7 +87,7 @@ class AutoBugLog {
                             $Title = $Title.Replace("{0}", $control.ControlItem.ControlID)
                             $Title = $Title.Replace("{1}", $control.ResourceContext.ResourceTypeName)
                             $Title = $Title.Replace("{2}", $control.ResourceContext.ResourceName)
-				
+				            
                             $Description = $Description.Replace("{0}", $control.ControlItem.Description)
                             $Description = $Description.Replace("{1}", $control.ControlItem.Rationale)
                             $Description = $Description.Replace("{2}", $control.ControlItem.Recommendation)
@@ -97,8 +97,8 @@ class AutoBugLog {
                             $Description = $Description.Replace("{6}", $control.ControlResults[0].VerificationResult)
                             $RunStepsForControl = " </br></br> <b>Control Scan Command:</b> Run:  {0}"
                             $RunStepsForControl = $RunStepsForControl.Replace("{0}", $this.GetControlReproStep($control))
-                            $Description+=$RunStepsForControl
-				
+                            $Description += $RunStepsForControl
+				            
 				
                             #check and append any detailed log and state data for the control failure
                             if ($this.GetDetailedLogForControl($control)) {
@@ -181,7 +181,7 @@ class AutoBugLog {
             }
             'User' {
                 #TODO: User controls dont have a project associated with them, can be rectified in future versions
-                Write-Host "`nAuto bug logging for user control failures is currently not supported." -ForegroundColor Red
+                Write-Host "`nAuto bug logging for user control failures is currently not supported." -ForegroundColor Yellow
                 return $false
             }
         }

--- a/src/AzSK.ADO/Framework/BugLog/BugLogPathManager.ps1
+++ b/src/AzSK.ADO/Framework/BugLog/BugLogPathManager.ps1
@@ -12,10 +12,11 @@ class BugLogPathManager {
     static hidden [bool] CheckIfPathIsValid([string] $OrgName,[string] $ProjectName, [InvocationInfo] $InvocationContext,[string] $ControlSettingsBugLogAreaPath, [string] $ControlSettingsBugLogIterationPath, [bool] $isBugLogCustomFlow) {
         
         #to check if we have checked path validity before
-        if ([BugLogPathManager]::checkValidPathFlag -or $isBugLogCustomFlow) {
+        #if customebug log true becase we get areapath from servicetree file so every time need to validate. if supply in cmd param
+        if ([BugLogPathManager]::checkValidPathFlag -or ($isBugLogCustomFlow -and !$InvocationContext.BoundParameters['AreaPath']) ) {
             [BugLogPathManager]::AreaPath = $null
             #checking path validity for the first time
-            $pathurl = "https://dev.azure.com/{0}/{1}/_apis/wit/wiql?api-version=5.1" -f $($OrgName), $ProjectName
+            $pathurl = 'https://dev.azure.com/{0}/{1}/_apis/wit/wiql?$top=1&api-version=5.1' -f $($OrgName), $ProjectName
             [BugLogPathManager]::AreaPath = $InvocationContext.BoundParameters['AreaPath'];
             [BugLogPathManager]::IterationPath = $InvocationContext.BoundParameters['IterationPath'];
 


### PR DESCRIPTION
## Description
</br>
Added top filter in area path validate api, 
restrict api call if area path is given in cmd and already validated, 
user bug not enable msg color changed to yellow

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
