### PR TITLE
Bug logging for specific controls, Refresh org policy in GADI in same PS session

### DIFF
--- a/src/AzSK.ADO/AzSKADOInfo/AzSKADOInfo.ps1
+++ b/src/AzSK.ADO/AzSKADOInfo/AzSKADOInfo.ps1
@@ -96,7 +96,6 @@ function Get-AzSKADOInfo
 	{
 		try 
 		{
-			$SubscriptionId = $OrganizationName
 			$unsupported = $false
 			if([string]::IsNullOrWhiteSpace($ResourceTypeName))
 			{
@@ -111,6 +110,12 @@ function Get-AzSKADOInfo
 
 			if(-not ([string]::IsNullOrEmpty($InfoType) -or $unsupported))
 			{
+				#Set empty, so org-policy get refreshed in every gadi run in same PS session.
+				[ConfigurationHelper]::PolicyCacheContent = @()
+			    [AzSKSettings]::Instance = $null
+			    [AzSKConfig]::Instance = $null 
+			    [ConfigurationHelper]::ServerConfigMetadata = $null
+			
 				switch ($InfoType.ToString()) 
 				{
 					OrganizationInfo
@@ -128,7 +133,7 @@ function Get-AzSKADOInfo
 							$Full = $false
 						}
 
-						$controlsInfo = [ControlsInfo]::new($SubscriptionId, $PSCmdlet.MyInvocation, $ResourceTypeName, $ControlIds, $UseBaselineControls, $UsePreviewBaselineControls, $FilterTags, $Full, $ControlSeverity, $ControlIdContains);
+						$controlsInfo = [ControlsInfo]::new($OrganizationName, $PSCmdlet.MyInvocation, $ResourceTypeName, $ControlIds, $UseBaselineControls, $UsePreviewBaselineControls, $FilterTags, $Full, $ControlSeverity, $ControlIdContains);
 						if ($controlsInfo) 
 						{
 							return $controlsInfo.InvokeFunction($controlsInfo.GetControlDetails);
@@ -136,7 +141,7 @@ function Get-AzSKADOInfo
 					}
 					HostInfo 
 					{
-						$hInfo = [HostInfo]::new($SubscriptionId, $PSCmdlet.MyInvocation);
+						$hInfo = [HostInfo]::new($OrganizationName, $PSCmdlet.MyInvocation);
 						if ($hInfo) 
 						{
 							return $hInfo.InvokeFunction($hInfo.GetHostInfo);

--- a/src/AzSK.ADO/Framework/BugLog/AutoBugLog.ps1
+++ b/src/AzSK.ADO/Framework/BugLog/AutoBugLog.ps1
@@ -105,7 +105,7 @@ class AutoBugLog {
                             $LogControlFlag = $this.CheckPreviewBaselineControl($control.ControlItem.ControlID)
                     }
                     elseif ($this.BugLogParameterValue -eq [BugLogForControls]::Custom) {
-                        $LogControlFlag = $this.CheckControlInCustomeControlList($control.ControlItem.ControlID)
+                        $LogControlFlag = $this.CheckControlInCustomControlList($control.ControlItem.ControlID)
                     }
 		
                     if ($LogControlFlag -and ($control.ControlResults[0].VerificationResult -eq "Failed" -or $control.ControlResults[0].VerificationResult -eq "Verify") ) {
@@ -632,7 +632,7 @@ class AutoBugLog {
         return $false
     }
 
-    hidden [bool] CheckControlInCustomeControlList($controlId) {
+    hidden [bool] CheckControlInCustomControlList($controlId) {
         if ([Helpers]::CheckMember($this.ControlSettings.BugLogging, "CustomControlList")) {
             $customControlList = $this.ControlSettings.BugLogging | Where-Object { $_.CustomControlList -contains $controlId }
             if (($customControlList | Measure-Object).Count -gt 0 ) {

--- a/src/AzSK.ADO/Framework/BugLog/AutoBugLog.ps1
+++ b/src/AzSK.ADO/Framework/BugLog/AutoBugLog.ps1
@@ -95,14 +95,17 @@ class AutoBugLog {
                     $control = $_;                                     
                     #filter controls on basis of whether they are baseline or not depending on the value given in autobuglog flag
                     $LogControlFlag = $false
-                    if ($this.BugLogParameterValue -eq "All") {
+                    if ($this.BugLogParameterValue -eq [BugLogForControls]::All) {
                             $LogControlFlag = $true
                     }
-                    elseif ($this.BugLogParameterValue -eq "BaselineControls") {
+                    elseif ($this.BugLogParameterValue -eq [BugLogForControls]::BaselineControls) {
                             $LogControlFlag = $this.CheckBaselineControl($control.ControlItem.ControlID)				
                     }
-                    else {
+                    elseif ($this.BugLogParameterValue -eq [BugLogForControls]::PreviewBaselineControls) {
                             $LogControlFlag = $this.CheckPreviewBaselineControl($control.ControlItem.ControlID)
+                    }
+                    elseif ($this.BugLogParameterValue -eq [BugLogForControls]::Custom) {
+                        $LogControlFlag = $this.CheckControlInCustomeControlList($control.ControlItem.ControlID)
                     }
 		
                     if ($LogControlFlag -and ($control.ControlResults[0].VerificationResult -eq "Failed" -or $control.ControlResults[0].VerificationResult -eq "Verify") ) {
@@ -629,7 +632,16 @@ class AutoBugLog {
         return $false
     }
 
-    
+    hidden [bool] CheckControlInCustomeControlList($controlId) {
+        if ([Helpers]::CheckMember($this.ControlSettings.BugLogging, "CustomControlList")) {
+            $customControlList = $this.ControlSettings.BugLogging | Where-Object { $_.CustomControlList -contains $controlId }
+            if (($customControlList | Measure-Object).Count -gt 0 ) {
+                return $true
+            }
+        }
+        
+        return $false
+    }
     
 }
 

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -367,7 +367,8 @@
     "HowFound": "Manual",
     "ComplianceArea": "Security",
     "ServiceTreeIdType": "Service",
-    "UseAzureStorageAccount": false
+    "UseAzureStorageAccount": false,
+    "CustomControlList": []
   },
   "GenerateSecurityEvaluationJsonFile" : false,
   "ResourceProviders": [

--- a/src/AzSK.ADO/Framework/Models/Enums.ps1
+++ b/src/AzSK.ADO/Framework/Models/Enums.ps1
@@ -169,3 +169,11 @@ enum AIOrgTelemetryStatus
 	Enabled
 	Disabled
 }
+
+enum BugLogForControls 
+{
+	All
+	BaselineControls
+	PreviewBaselineControls
+	Custom
+}

--- a/src/AzSK.ADO/SVT/SVT.ps1
+++ b/src/AzSK.ADO/SVT/SVT.ps1
@@ -198,10 +198,10 @@ function Get-AzSKADOSecurityStatus
 		$AttestationHostProjectName,
 
 
-		[ValidateSet("All","BaselineControls","PreviewBaselineControls")]
+		[ValidateSet("All","BaselineControls","PreviewBaselineControls", "Custom")]
 		[Parameter(Mandatory = $false)]
 		[Alias("abl")]		
-		[string] $AutoBugLog="All",		
+		[string] $AutoBugLog = [BugLogForControls]::All,
 
 		[string]
 		[Parameter(Mandatory=$false)]


### PR DESCRIPTION
Include changes:
Task 6905119: Log bugs only for a specific list of controls
Task 6905064: Refresh org policy between consecutive GADI calls

## Description
</br>
 Brief description of the requested change.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
