### PR TITLE
Added modified expiry at evaluation time

### DIFF
--- a/src/AzSK.ADO/Framework/Abstracts/ADOSVTBase.ps1
+++ b/src/AzSK.ADO/Framework/Abstracts/ADOSVTBase.ps1
@@ -177,6 +177,8 @@ class ADOSVTBase: SVTBase {
 								if ($approvedExceptionsControlList -contains $controlState.ControlId) {
 									$validatePreviousAttestation = $false
 									Write-Host "Per your org policy, this control now requires an associated approved exception id. Previous attestation has been invalidated." -ForegroundColor Yellow
+									#add to the dirty state list so that it can be removed later
+									$this.DirtyResourceStates += $childResourceState
 								}
 							}
 						}
@@ -345,15 +347,6 @@ class ADOSVTBase: SVTBase {
 						#Return -1 when expiry is not defined
 						else {
 							$expiryInDays = -1
-						}
-					}
-				}
-				if ([Helpers]::CheckMember($this.ControlSettings, "ExtendedAttestationExpiryResources") -and [Helpers]::CheckMember($this.ControlSettings, "ExtendedAttestationExpiryDuration")) {
-					if (($this.ControlSettings.ExtendedAttestationExpiryResources | Get-Member "ResourceType") -and ($this.ControlSettings.ExtendedAttestationExpiryResources | Get-Member "ResourceIds")) {
-						$extendedResources = $this.ControlSettings.ExtendedAttestationExpiryResources | Where { $_.ResourceType -match $controlState.FeatureName }
-						# type null check
-						if (($extendedResources | Measure-Object).Count -gt 0 -and [Helpers]::CheckMember($extendedResources, "ResourceIds") -and $controlState.ResourceId -in $extendedResources.ResourceIds) {
-							$expiryInDays = $this.ControlSettings.ExtendedAttestationExpiryDuration;
 						}
 					}
 				}

--- a/src/AzSK.ADO/Framework/Abstracts/ADOSVTBase.ps1
+++ b/src/AzSK.ADO/Framework/Abstracts/ADOSVTBase.ps1
@@ -275,7 +275,29 @@ class ADOSVTBase: SVTBase {
 		try {
 			#For exempt controls, either the no. of days for expiry were provided at the time of attestation or a default of 6 motnhs was already considered,
 			#therefore skipping this flow and calculating days directly using the expiry date already saved.
-			if ($controlState.AttestationStatus -ne [AttestationStatus]::ApprovedException) {
+			$isApprovedExceptionEnforced = $false
+			$approvedExceptionControlsList = @();
+			$expiryInDays = -1;
+			if ([Helpers]::CheckMember($this.ControlSettings, "EnforceApprovedException") -and ($this.ControlSettings.EnforceApprovedException -eq $true)) {
+				if ([Helpers]::CheckMember($this.ControlSettings, "ApprovedExceptionSettings") -and (($this.ControlSettings.ApprovedExceptionSettings.ControlsList | Measure-Object).Count -gt 0)) {
+					$isApprovedExceptionEnforced = $true
+					$approvedExceptionControlsList = $this.ControlSettings.ApprovedExceptionSettings.ControlsList
+				}
+			}
+			if (($controlState.AttestationStatus -eq [AttestationStatus]::ApprovedException) -or ( $isApprovedExceptionEnforced -and $approvedExceptionControlsList -contains $controlState.ControlId)) {
+				$expiryInDays = $this.ControlSettings.DefaultAttestationPeriodForExemptControl
+			}
+			elseif([Helpers]::CheckMember($this.ControlSettings, "ExtendedAttestationExpiryResources") -and [Helpers]::CheckMember($this.ControlSettings, "ExtendedAttestationExpiryDuration")){
+				# Checking if the resource id is present in extended expiry list of control settings
+				if(($this.ControlSettings.ExtendedAttestationExpiryResources | Get-Member "ResourceType") -and ($this.ControlSettings.ExtendedAttestationExpiryResources | Get-Member "ResourceIds")) {
+					$extendedResources = $this.ControlSettings.ExtendedAttestationExpiryResources | Where { $_.ResourceType -match $eventcontext.FeatureName }
+					# type null check
+					if(($extendedResources | Measure-Object).Count -gt 0 -and [Helpers]::CheckMember($extendedResources, "ResourceIds") -and $controlState.ResourceId -in $extendedResources.ResourceIds){
+						$expiryInDays = $this.ControlSettings.ExtendedAttestationExpiryDuration;
+					}
+				}
+			}
+			elseif ($controlState.AttestationStatus -ne [AttestationStatus]::ApprovedException) {
 				#Get controls expiry period. Default value is zero
 				$controlAttestationExpiry = $eventcontext.controlItem.AttestationExpiryPeriodInDays
 				$controlSeverity = $eventcontext.controlItem.ControlSeverity
@@ -295,6 +317,7 @@ class ADOSVTBase: SVTBase {
 					$defaultAttestationExpiryInDays = $this.ControlSettings.AttestationExpiryPeriodInDays.Default
 				}
 				#Expiry in the case of WillFixLater or StateConfirmed/Recurring Attestation state will be based on Control Severity.
+				# Checking if the resource id is present in extended expiry list of control settings
 				if ($controlState.AttestationStatus -eq [AttestationStatus]::NotAnIssue -or $controlState.AttestationStatus -eq [AttestationStatus]::NotApplicable) {
 					$expiryInDays = $defaultAttestationExpiryInDays;
 				}
@@ -322,6 +345,15 @@ class ADOSVTBase: SVTBase {
 						#Return -1 when expiry is not defined
 						else {
 							$expiryInDays = -1
+						}
+					}
+				}
+				if ([Helpers]::CheckMember($this.ControlSettings, "ExtendedAttestationExpiryResources") -and [Helpers]::CheckMember($this.ControlSettings, "ExtendedAttestationExpiryDuration")) {
+					if (($this.ControlSettings.ExtendedAttestationExpiryResources | Get-Member "ResourceType") -and ($this.ControlSettings.ExtendedAttestationExpiryResources | Get-Member "ResourceIds")) {
+						$extendedResources = $this.ControlSettings.ExtendedAttestationExpiryResources | Where { $_.ResourceType -match $controlState.FeatureName }
+						# type null check
+						if (($extendedResources | Measure-Object).Count -gt 0 -and [Helpers]::CheckMember($extendedResources, "ResourceIds") -and $controlState.ResourceId -in $extendedResources.ResourceIds) {
+							$expiryInDays = $this.ControlSettings.ExtendedAttestationExpiryDuration;
 						}
 					}
 				}


### PR DESCRIPTION
## Description
</br>
Post control evaluation, we are fetching the expiry time for controls attested, that should be configurable.
## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
