### PR TITLE
ResourceId updation for commonSVT

### DIFF
--- a/src/AzSK.ADO/Framework/Core/SVT/CommonSVTResourceResolver.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/CommonSVTResourceResolver.ps1
@@ -5,10 +5,12 @@ class CommonSVTResourceResolver {
     [ResourceTypeName] $ResourceTypeName = [ResourceTypeName]::All;
 
     [string] $organizationName
+    [string] $organizationId
     [string] $projectId
 
-    CommonSVTResourceResolver($organizationName, $projectId) {
+    CommonSVTResourceResolver($organizationName, $organizationId, $projectId) {
         $this.organizationName = $organizationName;
+        $this.organizationId = $organizationId;
         $this.projectId = $projectId;
     }
 
@@ -25,7 +27,7 @@ class CommonSVTResourceResolver {
             if ($repoObjList.count -gt 0 -and [Helpers]::CheckMember($repoObjList[0], "Id")) {
                 $maxObjScan = $MaxObjectsToScan
                 foreach ($repo in $repoObjList) {
-                    $resourceId = "organization/{0}/project/{1}/repository/{2}" -f $this.organizationName, $this.projectId, $repo.id;
+                    $resourceId = "organization/{0}/project/{1}/repository/{2}" -f $this.organizationId, $this.projectId, $repo.id;
                     $SVTResources += $this.AddSVTResource($repo.name, $projectName, "ADO.Repository", $resourceId, $repo, $repo.webUrl);
                     if (--$maxObjScan -eq 0) { break; }
                 }
@@ -45,7 +47,7 @@ class CommonSVTResourceResolver {
             if ($secureFileObjList.count -gt 0 -and [Helpers]::CheckMember($secureFileObjList[0], "Id")) {
                 $maxObjScan = $MaxObjectsToScan
                 foreach ($securefile in $secureFileObjList) {
-                    $resourceId = "organization/{0}/project/{1}/securefile/{2}" -f $this.organizationName, $this.projectId, $securefile.Id;
+                    $resourceId = "organization/{0}/project/{1}/securefile/{2}" -f $this.organizationId, $this.projectId, $securefile.Id;
                     $secureFileLink = "https://dev.azure.com/{0}/{1}/_library?itemType=SecureFiles&view=SecureFileView&secureFileId={2}&path={3}" -f $this.organizationName, $projectName, $securefile.Id, $securefile.Name;
                     $SVTResources += $this.AddSVTResource($securefile.Name, $projectName, "ADO.SecureFile", $resourceId, $securefile, $secureFileLink);
                     if (--$maxObjScan -eq 0) { break; }
@@ -67,7 +69,7 @@ class CommonSVTResourceResolver {
             if ($feedObjList.count -gt 0 -and [Helpers]::CheckMember($feedObjList[0], "Id")) {
                 $maxObjScan = $MaxObjectsToScan
                 foreach ($feed in $feedObjList) {
-                    $resourceId = "organization/{0}/project/{1}/feed/{2}" -f $this.organizationName, $this.projectId, $feed.id;
+                    $resourceId = "organization/{0}/project/{1}/feed/{2}" -f $this.organizationId, $this.projectId, $feed.id;
                     $SVTResources += $this.AddSVTResource($feed.name, $projectName, "ADO.Feed", $resourceId, $feed, $feed.Url);
                     if (--$maxObjScan -eq 0) { break; }
                 }
@@ -88,7 +90,7 @@ class CommonSVTResourceResolver {
             if ($environmentObjList.count -gt 0 -and [Helpers]::CheckMember($environmentObjList[0], "Id")) {
                 $maxObjScan = $MaxObjectsToScan
                 foreach ($environment in $environmentObjList) {
-                    $resourceId = "organization/{0}/project/{1}/environment/{2}" -f $this.organizationName, $this.projectId, $environment.id;
+                    $resourceId = "organization/{0}/project/{1}/environment/{2}" -f $this.organizationId, $this.projectId, $environment.id;
                     $resourceLink = "https://dev.azure.com/{0}/{1}/_environments/{2}?view=resources" -f $this.organizationName, $environment.project.id, $environment.id;
                     $SVTResources += $this.AddSVTResource($environment.name, $projectName, "ADO.Environment", $resourceId, $environment, $resourceLink);
                     if (--$maxObjScan -eq 0) { break; }

--- a/src/AzSK.ADO/Framework/Core/SVT/SVTResourceResolver.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/SVTResourceResolver.ps1
@@ -638,7 +638,7 @@ class SVTResourceResolver: AzSKRoot {
 
                     #Ceating resource in common resource resolver
                     if ($this.RepoNames.count -gt 0 -or $this.SecureFileNames.count -ge 0 -or $this.FeedNames.count -gt 0 -or $this.EnvironmentNames.count -gt 0 -or ($this.ResourceTypeName -in ([ResourceTypeName]::Repository, [ResourceTypeName]::SecureFile, [ResourceTypeName]::Feed, [ResourceTypeName]::Environment))) {
-                        $commonSVTResourceResolverObj = [CommonSVTResourceResolver]::new($this.organizationName, $projectId);
+                        $commonSVTResourceResolverObj = [CommonSVTResourceResolver]::new($this.organizationName, $organizationId, $projectId);
                         $this.SVTResources += $commonSVTResourceResolverObj.LoadResourcesForScan($projectName, $this.RepoNames, $this.SecureFileNames, $this.FeedNames, $this.EnvironmentNames, $this.ResourceTypeName, $this.MaxObjectsToScan);
                     }
 


### PR DESCRIPTION
## Description
</br>
Previously resourceId was generating like organization/OrgName/... now changes to organization/orgId/.. same as other resources.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
