### PR TITLE
[2109] [7538719,7834158,7834080] Broder group controls improvements

### DIFF
--- a/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.AgentPool.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.AgentPool.json
@@ -142,7 +142,7 @@
     },
     {
       "ControlID": "ADO_AgentPool_AuthZ_Restrict_Broader_Group_Access",
-      "Description": "Broader groups (contributors, project valid users, etc.) should not have user/administrator privileges on agent pool.",
+      "Description": "Broader groups (contributors, project valid users, etc.) should not have excessive permissions on agent pool.",
       "Id": "AgentPool200",
       "ControlSeverity": "High",
       "Automated": "Yes",

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.ServiceConnection.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.ServiceConnection.json
@@ -217,7 +217,7 @@
     },
     {
       "ControlID": "ADO_ServiceConnection_AuthZ_Restrict_Broader_Group_Access",
-      "Description": "Broader groups (contributors, project valid users, etc.) should not have user/administrator privileges on service connection.",
+      "Description": "Broader groups (contributors, project valid users, etc.) should not have excessive permissions on service connection.",
       "Id": "ServiceConnection240",
       "ControlSeverity": "High",
       "Automated": "Yes",

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.VariableGroup.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.VariableGroup.json
@@ -74,7 +74,7 @@
           },
           {
             "ControlID": "ADO_VariableGroup_AuthZ_Restrict_Broader_Group_Access",
-            "Description": "Broader groups (contributors, project valid users, etc.) should not have administrator privileges on variable group.",
+            "Description": "Broader groups (contributors, project valid users, etc.) should not have excessive permissions on variable group.",
             "Id": "VariableGroup160",
             "ControlSeverity": "High",
             "Automated": "Yes",

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -277,19 +277,35 @@
         "Environment",
         "SolutionName"
     ],
-    "RestrictedBroaderGroupsForBuild" : [
-      "Contributors",
-      "Readers",
-      "Project Collection Valid Users",
-      "Project Valid Users"
-    ],
-    "ExcessivePermissionsForBroadGroups": [
-      "Administer build permissions",
-      "Delete build pipeline",
-      "Delete builds ",
-      "Destroy builds",
-      "Edit build pipeline"
-    ],
+    "RestrictedBroaderGroupsForBuild" : {
+      "Contributors":[
+        "Administer build permissions",
+        "Delete build pipeline",
+        "Delete builds ",
+        "Destroy builds"
+      ],
+      "Readers":[
+        "Administer build permissions",
+        "Delete build pipeline",
+        "Delete builds ",
+        "Destroy builds",
+        "Edit build pipeline"
+      ],
+      "Project Collection Valid Users":[
+        "Administer build permissions",
+        "Delete build pipeline",
+        "Delete builds ",
+        "Destroy builds",
+        "Edit build pipeline"
+      ],
+      "Project Valid Users":[
+        "Administer build permissions",
+        "Delete build pipeline",
+        "Delete builds ",
+        "Destroy builds",
+        "Edit build pipeline"
+      ]
+    },
     "CheckForInheritedPermissions" : false,
     "RegexForOAuthTokenInYAMLScript" : "\\s*:\\s*\\$\\s*\\(\\s*System\\.AccessToken\\s*\\)",
     "BranchesToCheckForYAMLScript": ["master","main","develop"]
@@ -322,48 +338,89 @@
         "System.debug",
         "BuildConfiguration"
     ],
-    "RestrictedBroaderGroupsForRelease": [
-      "Contributors",
-      "Readers",
-      "Project Collection Valid Users",
-      "Project Valid Users"
-    ],
-    "ExcessivePermissionsForBroadGroups": [
-      "Administer release permissions",
-      "Delete release pipeline",
-      "Delete releases",
-      "Edit release pipeline",
-      "Delete release stage",      
-      "Edit release stage",
-      "Manage release approvers",
-      "Manage releases"
-    ],
+    "RestrictedBroaderGroupsForRelease" : {
+      "Contributors":[
+        "Administer release permissions",
+        "Delete release pipeline",
+        "Delete releases",
+        "Delete release stage",      
+        "Manage release approvers",
+        "Manage releases"
+      ],
+      "Readers":[
+        "Administer release permissions",
+        "Delete release pipeline",
+        "Delete releases",
+        "Edit release pipeline",
+        "Delete release stage",      
+        "Edit release stage",
+        "Manage release approvers",
+        "Manage releases"
+      ],
+      "Project Collection Valid Users":[
+        "Administer release permissions",
+        "Delete release pipeline",
+        "Delete releases",
+        "Edit release pipeline",
+        "Delete release stage",      
+        "Edit release stage",
+        "Manage release approvers",
+        "Manage releases"
+      ],
+      "Project Valid Users":[
+        "Administer release permissions",
+        "Delete release pipeline",
+        "Delete releases",
+        "Edit release pipeline",
+        "Delete release stage",      
+        "Edit release stage",
+        "Manage release approvers",
+        "Manage releases"
+      ]
+    },
     "CheckForInheritedPermissions": false
   },
   "AgentPool": {
     "AgentPoolHistoryPeriodInDays": 180 ,
-    "RestrictedBroaderGroupsForAgentPool": [
-        "Project Collection Valid Users",
-        "Contributors",
-        "Readers",
-        "Project Valid Users"
-    ],
-    "RestrictedRolesForBroaderGroupsInAgentPool": [
-      "Administrator",
-      "User"
-    ],
+    "RestrictedBroaderGroupsForAgentPool" : {
+      "Contributors":[
+        "Administrator",
+        "User"
+      ],
+      "Readers":[
+        "Administrator",
+        "User"
+      ],
+      "Project Collection Valid Users":[
+        "Administrator",
+        "User"
+      ],
+      "Project Valid Users":[
+        "Administrator",
+        "User"
+      ]
+    },
     "CheckForInheritedPermissions": false
   },
   "VariableGroup": {
-    "RestrictedBroaderGroupsForVariableGroup": [
-        "Project Collection Valid Users",
-        "Contributors",
-        "Readers",
-        "Project Valid Users"
-    ],
-    "RestrictedRolesForBroaderGroupsInVariableGroup": [
-        "Administrator"
-    ],
+    "RestrictedBroaderGroupsForVariableGroup" : {
+      "Contributors":[
+        "Administrator",
+        "User"
+      ],
+      "Readers":[
+        "Administrator",
+        "User"
+      ],
+      "Project Collection Valid Users":[
+        "Administrator",
+        "User"
+      ],
+      "Project Valid Users":[
+        "Administrator",
+        "User"
+      ]
+    },
     "RestrictedRolesForBroaderGroupsInVariableGroupContainingSecrets": [
       "Administrator",
       "User"
@@ -382,6 +439,15 @@
   "Wikis":{
     "ThreshHoldDaysForWikisInactivity":180
   }  ,
+  "BroaderGroupsToExpand":[
+    "Contributors"
+  ],
+  "VeryLargeGroups":[],
+  "CheckForBroadGroupMemberCount": true,
+  "AllowedMemberCountPerBroadGroup": {
+    "Contributors": 50,
+    "Project Valid Users": 40
+  },
   "AlernateAccountRegularExpressionForOrg": "^sc-\\w+@(?:\\w+\\.)*microsoft\\.com$|^\\w+.*@gme\\.gbl$",
   "ALTControlEvaluationMethod": "GraphThenRegEx",
   "Organization": {
@@ -440,41 +506,69 @@
     "AdminInactivityThresholdInDays": 90
   },
   "Feed":{
-  "RestrictedBroaderGroupsForFeeds": [
-    "Project Collection Valid Users",
-    "Contributors",
-    "Readers",
-    "Project Valid Users"
-    ],
-    "RestrictedRolesForBroaderGroupsInFeeds": [
-        "administrator",
-        "collaborator",
-        "contributor"
-    ]
+    "RestrictedBroaderGroupsForFeeds" : {
+      "Contributors":[
+        "Administrator",
+        "Collaborator",
+        "Contributor"
+      ],
+      "Readers":[
+        "Administrator",
+        "Collaborator",
+        "Contributor"
+      ],
+      "Project Collection Valid Users":[
+        "Administrator",
+        "Collaborator",
+        "Contributor"
+      ],
+      "Project Valid Users":[
+        "Administrator",
+        "Collaborator",
+        "Contributor"
+      ]
+    }
   },
   "SecureFile":{
-    "RestrictedBroaderGroupsForSecureFile": [
-      "Project Collection Valid Users",
-      "Contributors",
-      "Readers",
-      "Project Valid Users"
-    ],
-    "RestrictedRolesForBroaderGroupsInSecureFile": [
-      "administrator"       
-    ],
+    "RestrictedBroaderGroupsForSecureFile" : {
+      "Contributors":[
+        "Administrator",
+        "User"
+      ],
+      "Readers":[
+        "Administrator",
+        "User"
+      ],
+      "Project Collection Valid Users":[
+        "Administrator",
+        "User"
+      ],
+      "Project Valid Users":[
+        "Administrator",
+        "User"
+      ]
+    },
     "CheckForInheritedPermissions": false
   },
   "Environment":{
-    "RestrictedBroaderGroupsForEnvironment": [
-      "Project Collection Valid Users",
-      "Contributors",
-      "Readers",
-      "Project Valid Users"
-    ],
-    "RestrictedRolesForBroaderGroupsInEnv": [
-      "Administrator",
-      "User"       
-    ],
+    "RestrictedBroaderGroupsForEnvironment" : {
+      "Contributors":[
+        "Administrator",
+        "User"
+      ],
+      "Readers":[
+        "Administrator",
+        "User"
+      ],
+      "Project Collection Valid Users":[
+        "Administrator",
+        "User"
+      ],
+      "Project Valid Users":[
+        "Administrator",
+        "User"
+      ]
+    },
     "CheckForInheritedPermissions": false
   },
   "Repo": {
@@ -535,12 +629,24 @@
       "Contributors",
       "Readers"
     ],
-    "RestrictedBroaderGroupsForSvcConn": [
-      "Project Collection Valid Users",
-      "Contributors",
-      "Readers",
-      "Project Valid Users"
-    ],
+    "RestrictedBroaderGroupsForSvcConn" : {
+      "Contributors":[
+        "Administrator",
+        "User"
+      ],
+      "Readers":[
+        "Administrator",
+        "User"
+      ],
+      "Project Collection Valid Users":[
+        "Administrator",
+        "User"
+      ],
+      "Project Valid Users":[
+        "Administrator",
+        "User"
+      ]
+    },
     "CheckForInheritedPermissions": false
   },
   "Patterns": [

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -443,10 +443,9 @@
     "Contributors"
   ],
   "VeryLargeGroups":[],
-  "CheckForBroadGroupMemberCount": true,
+  "CheckForBroadGroupMemberCount": false,
   "AllowedMemberCountPerBroadGroup": {
-    "Contributors": 50,
-    "Project Valid Users": 40
+    "Contributors": 50
   },
   "AlernateAccountRegularExpressionForOrg": "^sc-\\w+@(?:\\w+\\.)*microsoft\\.com$|^\\w+.*@gme\\.gbl$",
   "ALTControlEvaluationMethod": "GraphThenRegEx",

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.AgentPool.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.AgentPool.ps1
@@ -410,52 +410,54 @@ class AgentPool: ADOSVTBase
     hidden [ControlResult] CheckBroaderGroupAccess ([ControlResult] $controlResult) {
         try {
             $controlResult.VerificationResult = [VerificationResult]::Failed
+            $restrictedBroaderGroups = @{}
+            $restrictedBroaderGroupsForAgentPool = $this.ControlSettings.AgentPool.RestrictedBroaderGroupsForAgentPool;
+            $restrictedBroaderGroupsForAgentPool.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
+            if (($this.AgentObj.Count -gt 0) -and [Helpers]::CheckMember($this.AgentObj, "identity")) {
+                # match all the identities added on agentpool with defined restricted list
+                $roleAssignmentsToCheck = $this.AgentObj
+                $restrictedGroups = @()
+                if ($this.checkInheritedPermissionsPerAgentPool -eq $false) {
+                    $roleAssignmentsToCheck = $this.AgentObj | where-object { $_.access -ne "inherited" }
+                }
+                $roleAssignments = @($roleAssignmentsToCheck | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}},@{Name="Id"; Expression = {$_.identity.id}}, @{Name="Role"; Expression = {$_.role.displayName}});
+                # Checking whether the broader groups have User/Admin permissions
+                $restrictedGroups = @($roleAssignments | Where-Object { $restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1] -and ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]])})
 
-            if ($this.ControlSettings -and [Helpers]::CheckMember($this.ControlSettings, "AgentPool.RestrictedBroaderGroupsForAgentPool")) {
-
-                $restrictedBroaderGroupsForAgentPool = $this.ControlSettings.AgentPool.RestrictedBroaderGroupsForAgentPool;
-                if (($this.AgentObj.Count -gt 0) -and [Helpers]::CheckMember($this.AgentObj, "identity")) {
-                    # match all the identities added on agentpool with defined restricted list
-                    $roleAssignmentsToCheck = $this.AgentObj
-                    if ($this.checkInheritedPermissionsPerAgentPool -eq $false) {
-                        $roleAssignmentsToCheck = $this.AgentObj | where-object { $_.access -ne "inherited" }
-                    }
-                    $roleAssignments = @($roleAssignmentsToCheck | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}},@{Name="Id"; Expression = {$_.identity.id}}, @{Name="Role"; Expression = {$_.role.displayName}});
-                    # Checking whether the broader groups have User/Admin permissions
-                    $restrictedGroups = @($roleAssignments | Where-Object { $restrictedBroaderGroupsForAgentPool -contains $_.Name.split('\')[-1] -and ($_.Role -eq "Administrator" -or $_.Role -eq "User") })
-
-                    $restrictedGroupsCount = $restrictedGroups.Count
-                    # fail the control if restricted group found on agentpool
-                    if ($restrictedGroupsCount -gt 0) {
-                        $controlResult.AddMessage([VerificationResult]::Failed, "Count of broader groups that have user/administrator access to agent pool: $($restrictedGroupsCount)");
-                        $formattedGroupsData = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} }, @{l = 'Role'; e = { $_.Role } }
-                        $backupDataObject = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} },@{l = 'Id'; e = { $_.Id } }, @{l = 'Role'; e = { $_.Role } }
-                        $formattedGroupsTable = ($formattedGroupsData | Out-String)
-                        $controlResult.AddMessage("`nList of groups: `n$formattedGroupsTable")
-                        $controlResult.SetStateData("List of groups: ", $restrictedGroups)
-                        $controlResult.AdditionalInfo += "Count of broader groups that have user/administrator access to agent pool: $($restrictedGroupsCount)";
-                        $groups = $restrictedGroups | ForEach-Object { $_.name + ': ' + $_.role } 
+                if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $restrictedGroups.Count -gt 0)
+                {
+                    $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($restrictedGroups, $true))
+                    $restrictedGroups = @($restrictedGroups | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+                }
+                $restrictedGroupsCount = $restrictedGroups.Count
+                # fail the control if restricted group found on agentpool
+                if ($restrictedGroupsCount -gt 0) {
+                    $controlResult.AddMessage([VerificationResult]::Failed, "Count of broader groups that have excessive permissions on agent pool: $($restrictedGroupsCount)");
+                    $formattedGroupsData = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} }, @{l = 'Role'; e = { $_.Role } }
+                    $backupDataObject = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} },@{l = 'Id'; e = { $_.Id } }, @{l = 'Role'; e = { $_.Role } }
+                    $formattedGroupsTable = ($formattedGroupsData | Out-String)
+                    $controlResult.AddMessage("`nList of groups: `n$formattedGroupsTable")
+                    $controlResult.SetStateData("List of groups: ", $restrictedGroups)
+                    $controlResult.AdditionalInfo += "Count of broader groups that have excessive permissions on agent pool: $($restrictedGroupsCount)";
+                    $groups = $restrictedGroups | ForEach-Object { $_.name + ': ' + $_.role } 
                         $controlResult.AdditionalInfoInCSV = $groups -join ' ; '
-                        
-                        if ($this.ControlFixBackupRequired) {
-                            #Data object that will be required to fix the control
-                            $controlResult.BackupControlState = $backupDataObject;
-                        }
-                    }
-                    else {
-                        $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have user/administrator access to agent pool.");
-                        $controlResult.AdditionalInfoInCSV = "NA";
+
+                    if ($this.ControlFixBackupRequired) {
+                        #Data object that will be required to fix the control
+                        $controlResult.BackupControlState = $backupDataObject;
                     }
                 }
                 else {
-                    $controlResult.AddMessage([VerificationResult]::Passed, "No groups have given access to agent pool.");
-                    $controlResult.AdditionalInfoInCSV = "NA";
+                    $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have excessive permissions on agent pool.");
+                        $controlResult.AdditionalInfoInCSV = "NA";
                 }
-                $controlResult.AddMessage("`nNote:`nThe following groups are considered 'broad' which should not have user/administrator privileges: `n$($restrictedBroaderGroupsForAgentPool | FT | out-string )`n");
             }
             else {
-                $controlResult.AddMessage([VerificationResult]::Error, "List of restricted broader groups for agent pool is not defined in control settings for your organization.");
+                $controlResult.AddMessage([VerificationResult]::Passed, "No groups have given access to agent pool.");
+                $controlResult.AdditionalInfoInCSV = "NA";
             }
+            $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+            $controlResult.AddMessage("Note:`nThe following groups are considered 'broad' which should not excessive permissions: `n$($displayObj | FT | out-string -width 512)");
         }
         catch {
             $controlResult.AddMessage([VerificationResult]::Error, "Could not fetch the agent pool permissions.");

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.AgentPool.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.AgentPool.ps1
@@ -418,7 +418,7 @@ class AgentPool: ADOSVTBase
                 $roleAssignmentsToCheck = $this.AgentObj
                 $restrictedGroups = @()
                 if ($this.checkInheritedPermissionsPerAgentPool -eq $false) {
-                    $roleAssignmentsToCheck = $this.AgentObj | where-object { $_.access -ne "inherited" }
+                    $roleAssignmentsToCheck = @($this.AgentObj | where-object { $_.access -ne "inherited" })
                 }
                 $roleAssignments = @($roleAssignmentsToCheck | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}},@{Name="Id"; Expression = {$_.identity.id}}, @{Name="Role"; Expression = {$_.role.displayName}});
                 # Checking whether the broader groups have User/Admin permissions
@@ -435,7 +435,7 @@ class AgentPool: ADOSVTBase
                     $controlResult.AddMessage([VerificationResult]::Failed, "Count of broader groups that have excessive permissions on agent pool: $($restrictedGroupsCount)");
                     $formattedGroupsData = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} }, @{l = 'Role'; e = { $_.Role } }
                     $backupDataObject = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} },@{l = 'Id'; e = { $_.Id } }, @{l = 'Role'; e = { $_.Role } }
-                    $formattedGroupsTable = ($formattedGroupsData | Out-String)
+                    $formattedGroupsTable = ($formattedGroupsData | FT -AutoSize | Out-String)
                     $controlResult.AddMessage("`nList of groups: `n$formattedGroupsTable")
                     $controlResult.SetStateData("List of groups: ", $restrictedGroups)
                     $controlResult.AdditionalInfo += "Count of broader groups that have excessive permissions on agent pool: $($restrictedGroupsCount)";
@@ -457,7 +457,7 @@ class AgentPool: ADOSVTBase
                 $controlResult.AdditionalInfoInCSV = "NA";
             }
             $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
-            $controlResult.AddMessage("Note:`nThe following groups are considered 'broad' which should not excessive permissions: `n$($displayObj | FT | out-string -width 512)");
+            $controlResult.AddMessage("Note:`nThe following groups are considered 'broad' which should not excessive permissions: `n$($displayObj | FT -AutoSize| out-string -width 512)");
         }
         catch {
             $controlResult.AddMessage([VerificationResult]::Error, "Could not fetch the agent pool permissions.");

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
@@ -1513,13 +1513,12 @@ class Build: ADOSVTBase
                             }
 
                             if ($groupsWithExcessivePermissionsList.count -gt 0) {
-                                #TODO: Do we need to put state object?
                                 $controlResult.AddMessage([VerificationResult]::Failed, "Broader groups have excessive permissions on the build pipeline.");
                                 $formattedGroupsData = $groupsWithExcessivePermissionsList | Select @{l = 'Group'; e = { $_.Group} }, @{l = 'ExcessivePermissions'; e = { $_.ExcessivePermissions } }
-                                $formattedBroaderGrpTable = ($formattedGroupsData | Out-String)
+                                $formattedBroaderGrpTable = ($formattedGroupsData | FT -AutoSize | Out-String)
                                 $controlResult.AddMessage("`nList of groups : `n$formattedBroaderGrpTable");
                                 $controlResult.AdditionalInfo += "List of excessive permissions on which contributors have access:  $($groupsWithExcessivePermissionsList.Group).";
-                                
+                                $controlResult.SetStateData("List of groups: ", $formattedGroupsData)
                                 $groups = $formattedGroupsData | ForEach-Object { $_.Group + ': ' + $_.ExcessivePermissions } 
                                 $controlResult.AdditionalInfoInCSV = $groups -join ' ; '
                                 

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.CommonSVTControls.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.CommonSVTControls.ps1
@@ -248,10 +248,11 @@ class CommonSVTControls: ADOSVTBase {
         $controlResult.VerificationResult = [VerificationResult]::Failed
         try
         {
-            $RestrictedBroaderGroupsForFeeds = $null;
-            if ([Helpers]::CheckMember($this.ControlSettings, "Feed.RestrictedBroaderGroupsForFeeds")) {
+            if ([Helpers]::CheckMember($this.ControlSettings, "Feed.RestrictedBroaderGroupsForFeeds"))
+            {
+                $restrictedBroaderGroups = @{}
                 $restrictedBroaderGroupsForFeeds = $this.ControlSettings.Feed.RestrictedBroaderGroupsForFeeds
-                $restrictedRolesForBroaderGroupsInFeeds = $this.ControlSettings.Feed.RestrictedRolesForBroaderGroupsInFeeds;
+                $restrictedBroaderGroupsForFeeds.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
                 #GET https://feeds.dev.azure.com/{organization}/{project}/_apis/packaging/Feeds/{feedId}/permissions?api-version=6.0-preview.1
                 #Using visualstudio api because new api (dev.azure.com) is giving null in the displayName property.
@@ -269,18 +270,25 @@ class CommonSVTControls: ADOSVTBase {
                     $controlResult.AddMessage("`n***Project scoped feed***")
                 }
                 $feedPermissionList = @([WebRequestHelper]::InvokeGetWebRequest($url));
-                $excesiveFeedsPermissions = @($feedPermissionList | Where-Object {($restrictedRolesForBroaderGroupsInFeeds -contains $_.role) -and ($restrictedBroaderGroupsForFeeds -contains $_.DisplayName.split('\')[-1])}) 
-                $feedWithBroaderGroup = @($excesiveFeedsPermissions | Select-Object -Property @{Name="FeedName"; Expression = {$this.ResourceContext.ResourceName}},@{Name="Role"; Expression = {$_.role}},@{Name="DisplayName"; Expression = {$_.displayName}}) ;
+                $excesiveFeedsPermissions = @($feedPermissionList | Where-Object { $restrictedBroaderGroups.keys -contains $_.displayName.split('\')[-1] -and ($_.role -in $restrictedBroaderGroups[$_.displayName.split('\')[-1]])})
+                $feedWithBroaderGroup = @($excesiveFeedsPermissions | Select-Object -Property @{Name="FeedName"; Expression = {$this.ResourceContext.ResourceName}},@{Name="Role"; Expression = {$_.role}},@{Name="Name"; Expression = {$_.displayName}}) ;
+
+                if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $feedWithBroaderGroup.Count -gt 0)
+                {
+                    $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($feedWithBroaderGroup, $true))
+                    $feedWithBroaderGroup = @($feedWithBroaderGroup | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+                }
+
                 $feedWithBroaderGroupCount = $feedWithBroaderGroup.count;
 
                 if ($feedWithBroaderGroupCount -gt 0)
                 {
                     $controlResult.AddMessage([VerificationResult]::Failed, "Count of broader groups that have administrator/contributor/collaborator access to feed: $($feedWithBroaderGroupCount)")
 
-                    $display = ($feedWithBroaderGroup |  FT FeedName, Role, DisplayName -AutoSize | Out-String -Width 512)
+                    $display = ($feedWithBroaderGroup |  FT Name, Role -AutoSize | Out-String -Width 512)
                     $controlResult.AddMessage("`nList of groups: ", $display)
                     $controlResult.SetStateData("List of groups: ", $feedWithBroaderGroup);
-                    $groups = $feedWithBroaderGroup | ForEach-Object { $_.DisplayName + ': ' + $_.Role } 
+                    $groups = $feedWithBroaderGroup | ForEach-Object { $_.Name + ': ' + $_.Role } 
                     $controlResult.AdditionalInfoInCSV = $groups -join ' ; '
 
                     if ($this.ControlFixBackupRequired)
@@ -297,7 +305,8 @@ class CommonSVTControls: ADOSVTBase {
                     $controlResult.AddMessage([VerificationResult]::Passed,  "Feed is not granted with administrator/contributor/collaborator permission to broad groups.");
                     $controlResult.AdditionalInfoInCSV = "NA";
                 }
-                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($restrictedBroaderGroupsForFeeds | FT | out-string)");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT | out-string)");
             }
             else
             {
@@ -409,9 +418,10 @@ class CommonSVTControls: ADOSVTBase {
         $controlResult.VerificationResult = [VerificationResult]::Failed
         try
         {
-            $restrictedBroaderGroupsForSecureFile = $null;
             if ([Helpers]::CheckMember($this.ControlSettings, "SecureFile.RestrictedBroaderGroupsForSecureFile")) {
+                $restrictedBroaderGroups = @{}
                 $restrictedBroaderGroupsForSecureFile = $this.ControlSettings.SecureFile.RestrictedBroaderGroupsForSecureFile
+                $restrictedBroaderGroupsForSecureFile.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
                 $projectId = ($this.ResourceContext.ResourceId -split "project/")[-1].Split('/')[0]
                 $url = 'https://dev.azure.com/{0}/_apis/securityroles/scopes/distributedtask.securefile/roleassignments/resources/{1}%24{2}' -f $this.OrganizationContext.OrganizationName, $projectId, $this.ResourceContext.ResourceDetails.Id;
@@ -422,15 +432,22 @@ class CommonSVTControls: ADOSVTBase {
                     $roleAssignmentsToCheck = $secureFilePermissionList | where-object { $_.access -ne "inherited" }
                 }
                 
-                $excesiveSecureFilePermissions = @(($roleAssignmentsToCheck | Where-Object {$_.role.name -eq "administrator" -or $_.role.name -eq "user"}) | Select-Object -Property @{Name="SecureFileName"; Expression = {$this.ResourceContext.ResourceName}},@{Name="Role"; Expression = {$_.role.name}},@{Name="DisplayName"; Expression = {$_.identity.displayName}}, @{Name="Id"; Expression = {$_.identity.id}}) ;
-                $secureFileWithBroaderGroup = @($excesiveSecureFilePermissions | Where-Object { $restrictedBroaderGroupsForSecureFile -contains $_.DisplayName.split('\')[-1] })
+                $excesiveSecureFilePermissions = @($roleAssignmentsToCheck | Where-Object { $restrictedBroaderGroups.keys -contains $_.identity.displayName.split('\')[-1] -and ($_.role.name -in $restrictedBroaderGroups[$_.identity.displayName.split('\')[-1]])})
+                $secureFileWithBroaderGroup = @($excesiveSecureFilePermissions | Select-Object -Property @{Name="SecureFileName"; Expression = {$this.ResourceContext.ResourceName}},@{Name="Role"; Expression = {$_.role.name}},@{Name="Name"; Expression = {$_.identity.displayName}}, @{Name="Id"; Expression = {$_.identity.id}}) ;
+
+                if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $secureFileWithBroaderGroup.Count -gt 0)
+                {
+                    $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($secureFileWithBroaderGroup, $true))
+                    $secureFileWithBroaderGroup = @($secureFileWithBroaderGroup | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+                }
+
                 $secureFileWithBroaderGroupCount = $secureFileWithBroaderGroup.count;
 
                 if ($secureFileWithBroaderGroupCount -gt 0)
                 {
                     $controlResult.AddMessage([VerificationResult]::Failed, "Count of broader groups that have user/administrator access to secure file: $($secureFileWithBroaderGroupCount)")
-
-                    $display = ($secureFileWithBroaderGroup |  FT SecureFileName, Role, DisplayName -AutoSize | Out-String -Width 512)
+                    
+                    $display = ($secureFileWithBroaderGroup |  FT  Name, Role -AutoSize | Out-String -Width 512)
                     $controlResult.AddMessage("`nList of groups: ", $display)
 
                     if ($this.ControlFixBackupRequired) {
@@ -438,14 +455,15 @@ class CommonSVTControls: ADOSVTBase {
                         $controlResult.BackupControlState = $secureFileWithBroaderGroup;
                     }
 
-                    $groups = $secureFileWithBroaderGroup | ForEach-Object { $_.DisplayName + ': ' + $_.Role } 
+                    $groups = $secureFileWithBroaderGroup | ForEach-Object { $_.Name + ': ' + $_.Role } 
                     $controlResult.AdditionalInfoInCSV = $groups -join ' ; '
                 }
                 else
                 {
                     $controlResult.AddMessage([VerificationResult]::Passed,  "Secure file is not granted with user/administrator permission to broad groups.");
                 }
-                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($restrictedBroaderGroupsForSecureFile | FT | out-string)");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT | out-string)");
             }
             else
             {
@@ -547,9 +565,10 @@ class CommonSVTControls: ADOSVTBase {
         $controlResult.VerificationResult = [VerificationResult]::Failed
         try
         {
-            $restrictedBroaderGroupsForEnvironment = $null;
             if ([Helpers]::CheckMember($this.ControlSettings, "Environment.RestrictedBroaderGroupsForEnvironment")) {
+                $restrictedBroaderGroups = @{}
                 $restrictedBroaderGroupsForEnvironment = $this.ControlSettings.Environment.RestrictedBroaderGroupsForEnvironment
+                $restrictedBroaderGroupsForEnvironment.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
                 $projectId = ($this.ResourceContext.ResourceId -split "project/")[-1].Split('/')[0]
                 $url = 'https://dev.azure.com/{0}/_apis/securityroles/scopes/distributedtask.environmentreferencerole/roleassignments/resources/{1}_{2}' -f $this.OrganizationContext.OrganizationName, $projectId, $this.ResourceContext.ResourceDetails.Id;
@@ -560,22 +579,30 @@ class CommonSVTControls: ADOSVTBase {
                     $roleAssignmentsToCheck = $environmentPermissionList | where-object { $_.access -ne "inherited" }
                 }
                 
-                $excesiveEnvironmentPermissions = @(($roleAssignmentsToCheck | Where-Object {$_.role.name -eq "administrator" -or $_.role.name -eq "user"}) | Select-Object -Property @{Name="EnvironmentName"; Expression = {$this.ResourceContext.ResourceName}},@{Name="Role"; Expression = {$_.role.name}},@{Name="DisplayName"; Expression = {$_.identity.displayName}}) ;
-                $environmentWithBroaderGroup = @($excesiveEnvironmentPermissions | Where-Object { $restrictedBroaderGroupsForEnvironment -contains $_.DisplayName.split('\')[-1] })
+                $excesiveEnvironmentPermissions = @($roleAssignmentsToCheck | Where-Object { $restrictedBroaderGroups.keys -contains $_.identity.displayName.split('\')[-1] -and ($_.role.name -in $restrictedBroaderGroups[$_.identity.displayName.split('\')[-1]])})
+                $environmentWithBroaderGroup = @($excesiveEnvironmentPermissions | Select-Object -Property @{Name="EnvironmentName"; Expression = {$this.ResourceContext.ResourceName}},@{Name="Role"; Expression = {$_.role.name}},@{Name="Name"; Expression = {$_.identity.displayName}}) ;
+
+                if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $environmentWithBroaderGroup.Count -gt 0)
+                {
+                    $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($environmentWithBroaderGroup, $true))
+                    $environmentWithBroaderGroup = @($environmentWithBroaderGroup | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+                }
+                
                 $environmentWithBroaderGroupCount = $environmentWithBroaderGroup.count;
 
                 if ($environmentWithBroaderGroupCount -gt 0)
                 {
                     $controlResult.AddMessage([VerificationResult]::Failed, "Count of broader groups that have user/administrator access to environment: $($environmentWithBroaderGroupCount)")
-
-                    $display = ($environmentWithBroaderGroup |  FT EnvironmentName, Role, DisplayName -AutoSize | Out-String -Width 512)
+                    
+                    $display = ($environmentWithBroaderGroup |  FT Name, Role -AutoSize | Out-String -Width 512)
                     $controlResult.AddMessage("`nList of groups: ", $display)
                 }
                 else
                 {
                     $controlResult.AddMessage([VerificationResult]::Passed,  "Environment is not granted with user/administrator permission to broad groups.");
                 }
-                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($restrictedBroaderGroupsForEnvironment | FT | out-string)");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT | out-string)");
             }
             else
             {

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.CommonSVTControls.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.CommonSVTControls.ps1
@@ -306,7 +306,7 @@ class CommonSVTControls: ADOSVTBase {
                     $controlResult.AdditionalInfoInCSV = "NA";
                 }
                 $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
-                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT | out-string)");
+                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT -AutoSize | out-string)");
             }
             else
             {
@@ -463,7 +463,7 @@ class CommonSVTControls: ADOSVTBase {
                     $controlResult.AddMessage([VerificationResult]::Passed,  "Secure file is not granted with user/administrator permission to broad groups.");
                 }
                 $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
-                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT | out-string)");
+                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT -AutoSize | out-string)");
             }
             else
             {
@@ -602,7 +602,7 @@ class CommonSVTControls: ADOSVTBase {
                     $controlResult.AddMessage([VerificationResult]::Passed,  "Environment is not granted with user/administrator permission to broad groups.");
                 }
                 $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
-                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT | out-string)");
+                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT -AutoSize | out-string)");
             }
             else
             {

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Project.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Project.ps1
@@ -2072,9 +2072,10 @@ class Project: ADOSVTBase
             $projectId = ($this.ResourceContext.ResourceId -split "project/")[-1].Split('/')[0]
             $projectName = $this.ResourceContext.ResourceName;
             $permissionSetToken = $projectId
-            if ([Helpers]::CheckMember($this.ControlSettings.Build, "RestrictedBroaderGroupsForBuild") -and [Helpers]::CheckMember($this.ControlSettings.Build, "ExcessivePermissionsForBroadGroups")) {
+            if ([Helpers]::CheckMember($this.ControlSettings.Build, "RestrictedBroaderGroupsForBuild")) {
+                $restrictedBroaderGroups = @{}
                 $broaderGroups = $this.ControlSettings.Build.RestrictedBroaderGroupsForBuild
-                $excessivePermissions = $this.ControlSettings.Build.ExcessivePermissionsForBroadGroups
+                $broaderGroups.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
                 $namespacesApiURL = "https://dev.azure.com/{0}/_apis/securitynamespaces?api-version=6.0" -f $($orgName)
                 $securityNamespacesObj = [WebRequestHelper]::InvokeGetWebRequest($namespacesApiURL);
                 $buildSecurityNamespaceId = ($securityNamespacesObj | Where-Object { ($_.Name -eq "Build") -and ($_.actions.name -contains "ViewBuilds")}).namespaceId
@@ -2109,11 +2110,12 @@ class Project: ADOSVTBase
                 $responseObj = [WebRequestHelper]::InvokePostWebRequest($apiURL, $inputbody);
                 if ([Helpers]::CheckMember($responseObj[0], "dataProviders") -and ($responseObj[0].dataProviders.'ms.vss-admin-web.security-view-members-data-provider') -and ([Helpers]::CheckMember($responseObj[0].dataProviders.'ms.vss-admin-web.security-view-members-data-provider', "identities"))) {
 
-                    $broaderGroupsList = @($responseObj[0].dataProviders.'ms.vss-admin-web.security-view-members-data-provider'.identities | Where-Object { $_.subjectKind -eq 'group' -and $broaderGroups -contains $_.displayName })
+                    $broaderGroupsList = @($responseObj[0].dataProviders.'ms.vss-admin-web.security-view-members-data-provider'.identities | Where-Object { $_.subjectKind -eq 'group' -and $restrictedBroaderGroups.keys -contains $_.displayName })
                     # $broaderGroupsList would be empty if none of its permissions are set i.e. all perms are 'Not Set'.
 
                     if ($broaderGroupsList.Count) {
                         $groupsWithExcessivePermissionsList = @()
+                        $filteredBroaderGroupList = @()
                         foreach ($broderGroup in $broaderGroupsList) {
                             $broaderGroupInputbody = "{
                                 'contributionIds': [
@@ -2142,7 +2144,7 @@ class Project: ADOSVTBase
                             #Web request to fetch RBAC permissions of broader groups on build.
                             $broaderGroupResponseObj = [WebRequestHelper]::InvokePostWebRequest($apiURL, $broaderGroupInputbody);
                             $broaderGroupRBACObj = $broaderGroupResponseObj[0].dataProviders.'ms.vss-admin-web.security-view-permissions-data-provider'.subjectPermissions
-                            $excessivePermissionList = $broaderGroupRBACObj | Where-Object { $_.displayName -in $excessivePermissions }
+                            $excessivePermissionList = $broaderGroupRBACObj | Where-Object { $_.displayName -in $restrictedBroaderGroups[$broderGroup.principalName.split('\')[-1]] }
                             $excessiveEditPermissions = @()
                             $excessivePermissionList | ForEach-Object {
                                 #effectivePermissionValue equals to 1 implies edit build pipeline perms is set to 'Allow'. Its value is 3 if it is set to Allow (inherited). This param is not available if it is 'Not Set'.
@@ -2160,8 +2162,16 @@ class Project: ADOSVTBase
                                 $excessivePermissionsGroupObj['PermissionSetToken'] = $permissionSetToken
                                 $excessivePermissionsGroupObj['PermissionSetId'] = $buildSecurityNamespaceId
                                 $groupsWithExcessivePermissionsList += $excessivePermissionsGroupObj
+                                $filteredBroaderGroupList += $broderGroup
                             }
                         }
+
+                        if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $filteredBroaderGroupList.Count -gt 0)
+                        {
+                            $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($filteredBroaderGroupList, $false))
+                            $groupsWithExcessivePermissionsList = @($groupsWithExcessivePermissionsList | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Group})
+                        }
+
                         if ($groupsWithExcessivePermissionsList.count -gt 0) {
                             #TODO: Do we need to put state object?
                             $controlResult.AddMessage([VerificationResult]::Failed, "Build pipelines are set to inherit excessive permissions for a broad group of users at project level.");
@@ -2189,8 +2199,8 @@ class Project: ADOSVTBase
                 else {
                     $controlResult.AddMessage([VerificationResult]::Error, "Could not fetch RBAC details of the build pipelines at a project level.");
                 }
-                $controlResult.AddMessage("`nNote:`nFollowing groups are considered 'broad groups':`n$($broaderGroups | FT | Out-String )`n");
-                $controlResult.AddMessage("`nFollowing permissions are considered 'excessive':`n$($excessivePermissions | FT | Out-String  )`n");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("`nNote:`nFollowing groups are considered 'broad groups':`n$($displayObj | FT -AutoSize | Out-String -Width 512)");
             }
             else {
                 $controlResult.AddMessage([VerificationResult]::Error, "Broader groups or excessive permissions are not defined in control settings for your organization.");
@@ -2292,9 +2302,10 @@ class Project: ADOSVTBase
             $projectId = ($this.ResourceContext.ResourceId -split "project/")[-1].Split('/')[0]
             $projectName = $this.ResourceContext.ResourceName;
             $permissionSetToken = $projectId
-            if ([Helpers]::CheckMember($this.ControlSettings.Release, "RestrictedBroaderGroupsForRelease") -and [Helpers]::CheckMember($this.ControlSettings.Release, "ExcessivePermissionsForBroadGroups")) {
+            if ([Helpers]::CheckMember($this.ControlSettings.Release, "RestrictedBroaderGroupsForRelease")) {
+                $restrictedBroaderGroups = @{}
                 $broaderGroups = $this.ControlSettings.Release.RestrictedBroaderGroupsForRelease
-                $excessivePermissions = $this.ControlSettings.Release.ExcessivePermissionsForBroadGroups
+                $broaderGroups.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
                 $namespacesApiURL = "https://dev.azure.com/{0}/_apis/securitynamespaces?api-version=6.0" -f $($orgName)
                 $securityNamespacesObj = [WebRequestHelper]::InvokeGetWebRequest($namespacesApiURL);
                 $releaseSecurityNamespaceId = ($securityNamespacesObj | Where-Object { ($_.Name -eq "ReleaseManagement") -and ($_.actions.name -contains "ViewReleaseDefinition")}).namespaceId
@@ -2330,11 +2341,12 @@ class Project: ADOSVTBase
                 $responseObj = [WebRequestHelper]::InvokePostWebRequest($apiURL, $inputbody);
                 if ([Helpers]::CheckMember($responseObj[0], "dataProviders") -and ($responseObj[0].dataProviders.'ms.vss-admin-web.security-view-members-data-provider') -and ([Helpers]::CheckMember($responseObj[0].dataProviders.'ms.vss-admin-web.security-view-members-data-provider', "identities"))) {
 
-                    $broaderGroupsList = @($responseObj[0].dataProviders.'ms.vss-admin-web.security-view-members-data-provider'.identities | Where-Object { $_.subjectKind -eq 'group' -and $broaderGroups -contains $_.displayName })
+                    $broaderGroupsList = @($responseObj[0].dataProviders.'ms.vss-admin-web.security-view-members-data-provider'.identities | Where-Object { $_.subjectKind -eq 'group' -and $restrictedBroaderGroups.keys -contains $_.displayName })
                     # $broaderGroupsList would be empty if none of its permissions are set i.e. all perms are 'Not Set'.
 
                     if ($broaderGroupsList.Count) {
                         $groupsWithExcessivePermissionsList = @()
+                        $filteredBroaderGroupList = @()
                         foreach ($broderGroup in $broaderGroupsList) {
                             $broaderGroupInputbody = "{
                                 'contributionIds': [
@@ -2363,7 +2375,7 @@ class Project: ADOSVTBase
                             #Web request to fetch RBAC permissions of broader groups on release.
                             $broaderGroupResponseObj = [WebRequestHelper]::InvokePostWebRequest($apiURL, $broaderGroupInputbody);
                             $broaderGroupRBACObj = $broaderGroupResponseObj[0].dataProviders.'ms.vss-admin-web.security-view-permissions-data-provider'.subjectPermissions
-                            $excessivePermissionList = $broaderGroupRBACObj | Where-Object { $_.displayName -in $excessivePermissions }
+                            $excessivePermissionList = $broaderGroupRBACObj | Where-Object { $_.displayName -in $restrictedBroaderGroups[$broderGroup.principalName.split('\')[-1]] }
                             $excessiveEditPermissions = @()
                             $excessivePermissionList | ForEach-Object {
                                 #effectivePermissionValue equals to 1 implies edit release pipeline perms is set to 'Allow'. Its value is 3 if it is set to Allow (inherited). This param is not available if it is 'Not Set'.
@@ -2381,8 +2393,16 @@ class Project: ADOSVTBase
                                 $excessivePermissionsGroupObj['PermissionSetToken'] = $permissionSetToken
                                 $excessivePermissionsGroupObj['PermissionSetId'] = $releaseSecurityNamespaceId
                                 $groupsWithExcessivePermissionsList += $excessivePermissionsGroupObj
+                                $filteredBroaderGroupList += $broderGroup
                             }
                         }
+
+                        if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $filteredBroaderGroupList.Count -gt 0)
+                        {
+                            $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($filteredBroaderGroupList, $false))
+                            $groupsWithExcessivePermissionsList = @($groupsWithExcessivePermissionsList | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Group})
+                        }
+
                         if ($groupsWithExcessivePermissionsList.count -gt 0) {
                             #TODO: Do we need to put state object?
                             $controlResult.AddMessage([VerificationResult]::Failed, "Release pipelines are set to inherit excessive permissions for a broad group of users at project level.");
@@ -2412,8 +2432,8 @@ class Project: ADOSVTBase
                 else {
                     $controlResult.AddMessage([VerificationResult]::Error, "Could not fetch RBAC details of the pipelines at a project level.");
                 }
-                $controlResult.AddMessage("`nNote:`nFollowing groups are considered 'broad groups':`n$($broaderGroups | FT | Out-String)`n");
-                $controlResult.AddMessage("`nFollowing permissions are considered 'excessive':`n$($excessivePermissions | FT | Out-String)`n");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("`nNote:`nFollowing groups are considered 'broad groups':`n$($displayObj | FT -AutoSize | Out-String -Width 512)");
             }
             else {
                 $controlResult.AddMessage([VerificationResult]::Error, "Broader groups or excessive permissions are not defined in control settings for your organization.");
@@ -2513,19 +2533,26 @@ class Project: ADOSVTBase
             $apiURL = "https://dev.azure.com/{0}/_apis/securityroles/scopes/distributedtask.serviceendpointrole/roleassignments/resources/{1}" -f $($this.OrganizationContext.OrganizationName), $($projectId);
             $serviceEndPointIdentity = @([WebRequestHelper]::InvokeGetWebRequest($apiURL));
             $restrictedGroups = @();
+            $restrictedBroaderGroups = @{}
             if ([Helpers]::CheckMember($this.ControlSettings, "ServiceConnection.RestrictedBroaderGroupsForSvcConn") ) {
                 $restrictedBroaderGroupsForSvcConn = $this.ControlSettings.ServiceConnection.RestrictedBroaderGroupsForSvcConn;
-
+                $restrictedBroaderGroupsForSvcConn.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
                 if (($serviceEndPointIdentity.Count -gt 0) -and [Helpers]::CheckMember($serviceEndPointIdentity, "identity")) {
                     # match all the identities added on service connection with defined restricted list
                     $roleAssignments = @();
                     $roleAssignments +=   ($serviceEndPointIdentity | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}},@{Name="Id"; Expression = {$_.identity.Id}},@{Name="Role"; Expression = {$_.role.displayName}},@{Name="Access"; Expression = {$_.access}});
                     #Checking where broader groups have user/admin permission for service connection
                     if ([Helpers]::CheckMember($this.ControlSettings, "ServiceConnection.CheckForInheritedPermissions") -and $this.ControlSettings.ServiceConnection.CheckForInheritedPermissions) {
-                        $restrictedGroups += @($roleAssignments | Where-Object { $restrictedBroaderGroupsForSvcConn -contains $_.Name.split('\')[-1] -and ($_.Role -eq "Administrator" -or $_.Role -eq "User") })
+                        $restrictedGroups = @($roleAssignments | Where-Object { $restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1] -and ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })
                     }
                     else {
-                        $restrictedGroups += @($roleAssignments | Where-Object { $_.Access -eq "assigned" -and $restrictedBroaderGroupsForSvcConn -contains $_.Name.split('\')[-1] -and ($_.Role -eq "Administrator" -or $_.Role -eq "User") })
+                        $restrictedGroups = @($roleAssignments | Where-Object { $_.Access -eq "assigned" -and $restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1] -and ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })
+                    }
+
+                    if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $restrictedGroups.Count -gt 0)
+                    {
+                        $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($restrictedGroups, $true))
+                        $restrictedGroups = @($restrictedGroups | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
                     }
 
                     $restrictedGroupsCount = $restrictedGroups.Count
@@ -2554,7 +2581,8 @@ class Project: ADOSVTBase
                 else {
                     $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have user/administrator access to service connection at a project level.");
                 }
-                $controlResult.AddMessage("`nNote:`nThe following groups are considered 'broad' which should not have user/administrator privileges: `n$($restrictedBroaderGroupsForSvcConn | FT | out-string )`n");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("`nNote:`nThe following groups are considered 'broad' which should not have excessive permissions: `n$($displayObj | FT | out-string -width 512)`n");
             }
             else {
                 $controlResult.AddMessage([VerificationResult]::Error, "List of broader groups for service connection is not defined in control settings for your organization.");
@@ -2626,24 +2654,31 @@ class Project: ADOSVTBase
         try {
             $controlResult.VerificationResult = [VerificationResult]::Failed
 
-            if ($this.ControlSettings -and [Helpers]::CheckMember($this.ControlSettings, "AgentPool.RestrictedBroaderGroupsForAgentPool") -and [Helpers]::CheckMember($this.ControlSettings, "AgentPool.RestrictedRolesForBroaderGroupsInAgentPool")) {
+            if ($this.ControlSettings -and [Helpers]::CheckMember($this.ControlSettings, "AgentPool.RestrictedBroaderGroupsForAgentPool")) {
                 $projectId = ($this.ResourceContext.ResourceId -split "project/")[-1].Split('/')[0]
                 $apiURL = "https://dev.azure.com/$($this.OrganizationContext.OrganizationName)/_apis/securityroles/scopes/distributedtask.agentqueuerole/roleassignments/resources/$($projectId)";
                 $agentPoolPermObj = @([WebRequestHelper]::InvokeGetWebRequest($apiURL));
+                $restrictedBroaderGroups = @{}
                 $restrictedBroaderGroupsForAgentPool = $this.ControlSettings.AgentPool.RestrictedBroaderGroupsForAgentPool;
-                $restrictedRolesForBroaderGroupsInAgentPool = $this.ControlSettings.AgentPool.RestrictedRolesForBroaderGroupsInAgentPool;
+                $restrictedBroaderGroupsForAgentPool.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
                 if (($agentPoolPermObj.Count -gt 0) -and [Helpers]::CheckMember($agentPoolPermObj, "identity")) {
                     # match all the identities added on agentpool with defined restricted list
-                    $roleAssignments = @($agentPoolPermObj | Select-Object -Property @{Name="ProjectName"; Expression = {$this.ResourceContext.ResourceName}},@{Name="DisplayName"; Expression = {$_.identity.displayName}},@{Name="Role"; Expression = {$_.role.displayName}},@{Name="RoleId"; Expression = {$_.identity.id}},@{Name="Access"; Expression = {$_.access}});
+                    $roleAssignments = @($agentPoolPermObj | Select-Object -Property @{Name="ProjectName"; Expression = {$this.ResourceContext.ResourceName}},@{Name="Name"; Expression = {$_.identity.displayName}},@{Name="Role"; Expression = {$_.role.displayName}},@{Name="RoleId"; Expression = {$_.identity.id}},@{Name="Access"; Expression = {$_.access}});
                     # Checking whether the broader groups have User/Admin permissions
                     $restrictedGroups = @();
 
                     if ([Helpers]::CheckMember($this.ControlSettings, "Agentpool.CheckForInheritedPermissions") -and $this.ControlSettings.Agentpool.CheckForInheritedPermissions) {
-                        $restrictedGroups = @($roleAssignments | Where-Object { $restrictedBroaderGroupsForAgentPool -contains $_.DisplayName.split('\')[-1] -and ($restrictedRolesForBroaderGroupsInAgentPool -Contains $_.Role) })
+                        $restrictedGroups = @($roleAssignments | Where-Object { $restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1] -and ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })
                     }
                     else {
-                        $restrictedGroups = @($roleAssignments | Where-Object { $_.Access -eq "assigned" -and $restrictedBroaderGroupsForAgentPool -contains $_.DisplayName.split('\')[-1] -and ($restrictedRolesForBroaderGroupsInAgentPool -Contains $_.Role) })                      
+                        $restrictedGroups = @($roleAssignments | Where-Object { $_.Access -eq "assigned" -and $restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1] -and ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })                      
+                    }
+
+                    if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $restrictedGroups.Count -gt 0)
+                    {
+                        $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($restrictedGroups, $true))
+                        $restrictedGroups = @($restrictedGroups | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
                     }
 
                     $restrictedGroupsCount = $restrictedGroups.Count
@@ -2651,7 +2686,7 @@ class Project: ADOSVTBase
                     if ($restrictedGroupsCount -gt 0) {
                         $controlResult.AddMessage([VerificationResult]::Failed, "Agent pools are set to inherit excessive permissions for a broad group of users at project level.");
                         $controlResult.AddMessage([VerificationResult]::Failed, "Count of broader groups: $($restrictedGroupsCount)");
-                        $formattedGroupsData = $restrictedGroups | Select @{l = 'Group'; e = { $_.DisplayName} }, @{l = 'Role'; e = { $_.Role } }
+                        $formattedGroupsData = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} }, @{l = 'Role'; e = { $_.Role } }
                         $formattedGroupsTable = ($formattedGroupsData | Out-String)
                         $controlResult.AddMessage("`nList of groups: $formattedGroupsTable")
                         $controlResult.SetStateData("List of groups: ", $restrictedGroups)
@@ -2661,7 +2696,7 @@ class Project: ADOSVTBase
                             #Data object that will be required to fix the control
                             $controlResult.BackupControlState = $restrictedGroups;
                         }
-                        $groups = $restrictedGroups | ForEach-Object { $_.DisplayName + ': ' + $_.role } 
+                        $groups = $restrictedGroups | ForEach-Object { $_.Name + ': ' + $_.role } 
                         $controlResult.AdditionalInfoInCSV = $groups -join ' ; '
                     }
                     else {
@@ -2671,7 +2706,8 @@ class Project: ADOSVTBase
                 else {
                     $controlResult.AddMessage([VerificationResult]::Passed, "No groups have given access to agent pool at a project level.");
                 }
-                $controlResult.AddMessage("`nNote:`nThe following groups are considered 'broad' which should not have user/administrator privileges: `n$($restrictedBroaderGroupsForAgentPool | FT | out-string )`n");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("Note:`nThe following groups are considered 'broad' which should not excessive permissions: `n$($displayObj | FT -AutoSize| out-string -width 512)");
             }
             else {
                 $controlResult.AddMessage([VerificationResult]::Error, "List of restricted broader groups and restricted roles for agent pools is not defined in the control settings for your organization policy.");
@@ -2705,7 +2741,7 @@ class Project: ADOSVTBase
 "@;
                 }
                 $RawDataObjForControlFix | Add-Member -NotePropertyName NewRole -NotePropertyValue "Reader"
-                $RawDataObjForControlFix = @($RawDataObjForControlFix  | Select-Object @{Name="DisplayName"; Expression={$_.DisplayName}}, @{Name="OldRole"; Expression={$_.Role}},@{Name="NewRole"; Expression={$_.NewRole}})
+                $RawDataObjForControlFix = @($RawDataObjForControlFix  | Select-Object @{Name="DisplayName"; Expression={$_.Name}}, @{Name="OldRole"; Expression={$_.Role}},@{Name="NewRole"; Expression={$_.NewRole}})
             }
             else {
                 foreach ($identity in $RawDataObjForControlFix) 
@@ -2718,7 +2754,7 @@ class Project: ADOSVTBase
 "@;
                 }
                 $RawDataObjForControlFix | Add-Member -NotePropertyName OldRole -NotePropertyValue "Reader"
-                $RawDataObjForControlFix = @($RawDataObjForControlFix  | Select-Object @{Name="DisplayName"; Expression={$_.DisplayName}}, @{Name="OldRole"; Expression={$_.OldRole}},@{Name="NewRole"; Expression={$_.Role}})
+                $RawDataObjForControlFix = @($RawDataObjForControlFix  | Select-Object @{Name="DisplayName"; Expression={$_.Name}}, @{Name="OldRole"; Expression={$_.OldRole}},@{Name="NewRole"; Expression={$_.Role}})
             }
 
             $body += "]"
@@ -2745,9 +2781,10 @@ class Project: ADOSVTBase
             $controlResult.VerificationResult = [VerificationResult]::Failed
             $projectId = ($this.ResourceContext.ResourceId -split "project/")[-1].Split('/')[0]
 
-            if ($this.ControlSettings -and [Helpers]::CheckMember($this.ControlSettings, "VariableGroup.RestrictedBroaderGroupsForVariableGroup") -and [Helpers]::CheckMember($this.ControlSettings, "VariableGroup.RestrictedRolesForBroaderGroupsInVariableGroup")) {
+            if ($this.ControlSettings -and [Helpers]::CheckMember($this.ControlSettings, "VariableGroup.RestrictedBroaderGroupsForVariableGroup") ) {
+                $restrictedBroaderGroups = @{}
                 $restrictedBroaderGroupsForVarGrp = $this.ControlSettings.VariableGroup.RestrictedBroaderGroupsForVariableGroup;
-                $restrictedRolesForBroaderGroupsInvarGrp = $this.ControlSettings.VariableGroup.RestrictedRolesForBroaderGroupsInVariableGroup;
+                $restrictedBroaderGroupsForVarGrp.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
                 #Fetch variable group RBAC
                 $roleAssignments = @();
@@ -2761,11 +2798,18 @@ class Project: ADOSVTBase
 
                 # Checking whether the broader groups have User/Admin permissions
                 if ([Helpers]::CheckMember($this.ControlSettings, "VariableGroup.CheckForInheritedPermissions") -and $this.ControlSettings.VariableGroup.CheckForInheritedPermissions) {
-                    $restrictedGroups = @($roleAssignments | Where-Object { ($restrictedBroaderGroupsForVarGrp -contains $_.Name.split('\')[-1]) -and  ($restrictedRolesForBroaderGroupsInvarGrp -contains $_.Role) })
+                    $restrictedGroups = @($roleAssignments | Where-Object { ($restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1]) -and  ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })
                 }
                 else {
-                    $restrictedGroups = @($roleAssignments | Where-Object { $_.Access -eq "assigned" -and  ($restrictedBroaderGroupsForVarGrp -contains $_.Name.split('\')[-1]) -and  ($restrictedRolesForBroaderGroupsInvarGrp -contains $_.Role) })
+                    $restrictedGroups = @($roleAssignments | Where-Object { $_.Access -eq "assigned" -and  ($restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1]) -and  ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })
                 }
+
+                if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $restrictedGroups.Count -gt 0)
+                {
+                    $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($restrictedGroups, $true))
+                    $restrictedGroups = @($restrictedGroups | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+                }
+
                 $restrictedGroupsCount = $restrictedGroups.Count
 
                 # fail the control if restricted group found on variable group
@@ -2787,7 +2831,8 @@ class Project: ADOSVTBase
                 else {
                     $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have administrator access to variable group at a project level.");
                 }
-                $controlResult.AddMessage("Note:`nThe following groups are considered 'broad' and should not have administrator privileges: `n$($restrictedBroaderGroupsForVarGrp | FT | out-string)");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("`nNote:`nThe following groups are considered 'broad' and should not have excessive permissions: `n$( $displayObj| FT | out-string -Width 512)");
             }
             else {
                 $controlResult.AddMessage([VerificationResult]::Error, "List of restricted broader groups and restricted roles for variable group is not defined in the control settings for your organization policy.");
@@ -2857,9 +2902,10 @@ class Project: ADOSVTBase
             $controlResult.VerificationResult = [VerificationResult]::Failed
             $projectId = $this.ResourceContext.ResourceDetails.Id
 
-            if ([Helpers]::CheckMember($this.ControlSettings, "SecureFile.RestrictedBroaderGroupsForSecureFile") -and [Helpers]::CheckMember($this.ControlSettings, "SecureFile.RestrictedRolesForBroaderGroupsInSecureFile")) {
+            if ([Helpers]::CheckMember($this.ControlSettings, "SecureFile.RestrictedBroaderGroupsForSecureFile")) {
+                $restrictedBroaderGroups = @{}
                 $restrictedBroaderGroupsForSecureFile = $this.ControlSettings.SecureFile.RestrictedBroaderGroupsForSecureFile;  
-                $restrictedRolesForBroaderGroupsInSecureFile = $this.ControlSettings.SecureFile.RestrictedRolesForBroaderGroupsInSecureFile;              
+                $restrictedBroaderGroupsForSecureFile.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
                 #Fetch Secure File RBAC
                 $roleAssignments = @();
@@ -2872,7 +2918,19 @@ class Project: ADOSVTBase
                 }
 
                 # Checking whether the broader groups have User/Admin permissions
-                $restrictedGroups = @($roleAssignments | Where-Object { ($restrictedBroaderGroupsForSecureFile -contains $_.Name.split('\')[-1]) -and  ($restrictedRolesForBroaderGroupsInSecureFile -contains $_.Role) })
+                if ([Helpers]::CheckMember($this.ControlSettings, "SecureFile.CheckForInheritedPermissions") -and $this.ControlSettings.SecureFile.CheckForInheritedPermissions) {
+                    $restrictedGroups = @($roleAssignments | Where-Object { ($restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1]) -and  ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })
+                }
+                else {
+                    $restrictedGroups = @($roleAssignments | Where-Object { $_.Access -eq "assigned" -and  ($restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1]) -and  ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })
+                }
+
+                if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $restrictedGroups.Count -gt 0)
+                {
+                    $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($restrictedGroups, $true))
+                    $restrictedGroups = @($restrictedGroups | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+                }
+
                 $restrictedGroupsCount = $restrictedGroups.Count
 
                 # fail the control if restricted group found on secure file
@@ -2892,7 +2950,8 @@ class Project: ADOSVTBase
                 else {
                     $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have administrator access to secure file at a project level.");
                 }
-                $controlResult.AddMessage("Note:`nThe following groups are considered 'broad' and should not have administrator privileges: `n$($restrictedBroaderGroupsForSecureFile | FT | out-string)");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT -AutoSize | out-string)");
             }
             else {
                 $controlResult.AddMessage([VerificationResult]::Error, "List of restricted broader groups and restricted roles for secure file is not defined in the control settings for your organization policy.");
@@ -3064,9 +3123,10 @@ class Project: ADOSVTBase
             $controlResult.VerificationResult = [VerificationResult]::Failed
             $projectId = $this.ResourceContext.ResourceDetails.Id
 
-            if ([Helpers]::CheckMember($this.ControlSettings, "Environment.RestrictedBroaderGroupsForEnvironment") -and [Helpers]::CheckMember($this.ControlSettings, "Environment.RestrictedRolesForBroaderGroupsInEnv")) {
+            if ([Helpers]::CheckMember($this.ControlSettings, "Environment.RestrictedBroaderGroupsForEnvironment")) {
+                $restrictedBroaderGroups = @{}
                 $RestrictedBroaderGroupsForEnvironment = $this.ControlSettings.Environment.RestrictedBroaderGroupsForEnvironment;
-                $restrictedRolesForBroaderGroupsInEnv = $this.ControlSettings.Environment.RestrictedRolesForBroaderGroupsInEnv;
+                $restrictedBroaderGroupsForEnvironment.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
                 #Fetch environment RBAC
                 $roleAssignments = @();
@@ -3075,11 +3135,23 @@ class Project: ADOSVTBase
                 $responseObj = @([WebRequestHelper]::InvokeGetWebRequest($url));
                 if($responseObj.Count -gt 0)
                 {
-                    $roleAssignments += ($responseObj  | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}}, @{Name="Role"; Expression = {$_.role.displayName}});
+                    $roleAssignments += ($responseObj  | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}}, @{Name="Role"; Expression = {$_.role.displayName}}, @{Name= "Access"; Expression = {$_.accessDisplayName}});
                 }
             
                 # Checking whether the broader groups have User/Admin permissions
-                $restrictedGroups = @($roleAssignments | Where-Object { ($RestrictedBroaderGroupsForEnvironment -contains $_.Name.split('\')[-1]) -and  ($restrictedRolesForBroaderGroupsInEnv -contains $_.Role) })
+                if ([Helpers]::CheckMember($this.ControlSettings, "Environment.CheckForInheritedPermissions") -and $this.ControlSettings.Environment.CheckForInheritedPermissions) {
+                    $restrictedGroups = @($roleAssignments | Where-Object { ($restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1]) -and  ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })
+                }
+                else {
+                    $restrictedGroups = @($roleAssignments | Where-Object { $_.Access -eq "assigned" -and  ($restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1]) -and  ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]]) })
+                }
+
+                if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $restrictedGroups.Count -gt 0)
+                {
+                    $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($restrictedGroups, $true))
+                    $restrictedGroups = @($restrictedGroups | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+                }
+
                 $restrictedGroupsCount = $restrictedGroups.Count
 
                 # fail the control if restricted group found on environment
@@ -3094,7 +3166,8 @@ class Project: ADOSVTBase
                 else {
                     $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have administrator/user access to environment at a project level.");
                 }
-                $controlResult.AddMessage("Note:`nThe following groups are considered 'broad' and should not have administrator privileges: `n$($RestrictedBroaderGroupsForEnvironment | FT | out-string)");
+                $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                $controlResult.AddMessage("`nNote: `nThe following groups are considered 'broader groups': `n$($displayObj | FT -AutoSize | out-string)");
             }
             else {
                 $controlResult.AddMessage([VerificationResult]::Error, "List of restricted broader groups and restricted roles for environment is not defined in the control settings for your organization policy.");

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.ServiceConnection.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.ServiceConnection.ps1
@@ -599,7 +599,7 @@ class ServiceConnection: ADOSVTBase
             else
             {
                 $controlResult.AddMessage([VerificationResult]::Failed, $this.SvcConnActivityDetail.message);
-                $controlResult.AdditionalInfoInCSV += "Serivce connection last run date not found.";   
+                $controlResult.AdditionalInfoInCSV += "Serivce connection last run date not found.";
             }
         }
         catch
@@ -882,7 +882,6 @@ class ServiceConnection: ADOSVTBase
 
     hidden [ControlResult] CheckBroaderGroupAccess ([ControlResult] $controlResult) {
         $controlResult.VerificationResult = [VerificationResult]::Failed
-        $failMsg = $null
 
         try {
             if ($null -eq $this.serviceEndPointIdentity) {
@@ -890,62 +889,62 @@ class ServiceConnection: ADOSVTBase
                 $this.serviceEndPointIdentity = @([WebRequestHelper]::InvokeGetWebRequest($apiURL));
             }
             $restrictedGroups = @();
+            $restrictedBroaderGroups = @{}
+            $restrictedBroaderGroupsForSvcConn = $this.ControlSettings.ServiceConnection.RestrictedBroaderGroupsForSvcConn;
+            #Converting controlsettings broader groups into a hashtable.
+            $restrictedBroaderGroupsForSvcConn.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
-            if ([Helpers]::CheckMember($this.ControlSettings, "ServiceConnection.RestrictedBroaderGroupsForSvcConn") ) {
-                $restrictedBroaderGroupsForSvcConn = $this.ControlSettings.ServiceConnection.RestrictedBroaderGroupsForSvcConn;
+            if (($this.serviceEndPointIdentity.Count -gt 0) -and [Helpers]::CheckMember($this.serviceEndPointIdentity, "identity")) {
+                # match all the identities added on service connection with defined restricted list
+                $roleAssignments = @();
+                $roleAssignmentsToCheck = $this.serviceEndPointIdentity
+                if ($this.checkInheritedPermissionsPerSvcConn -eq $false) {
+                    $roleAssignmentsToCheck = $this.serviceEndPointIdentity | where-object { $_.access -ne "inherited" }
+                }
+                $roleAssignments = @($roleAssignmentsToCheck | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}},@{Name="Id"; Expression = {$_.identity.id}},@{Name="AccessDisplayName"; Expression = {$_.accessDisplayName}},@{Name="Role"; Expression = {$_.role.displayName}});
+                #Checking where broader groups have excessive permission on service connection
+                $restrictedGroups += @($roleAssignments | Where-Object { $restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1] -and ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]])})
+                
+                if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $restrictedGroups.Count -gt 0)
+                {
+                    $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($restrictedGroups, $true))
+                    $restrictedGroups = @($restrictedGroups | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+                }
 
-                if (($this.serviceEndPointIdentity.Count -gt 0) -and [Helpers]::CheckMember($this.serviceEndPointIdentity, "identity")) {
-                    # match all the identities added on service connection with defined restricted list
-                    $roleAssignments = @();
-                    $roleAssignmentsToCheck = $this.serviceEndPointIdentity
-                    if ($this.checkInheritedPermissionsPerSvcConn -eq $false) {
-                        $roleAssignmentsToCheck = $this.serviceEndPointIdentity | where-object { $_.access -ne "inherited" }
+                $restrictedGroupsCount = $restrictedGroups.Count
+
+                # fail the control if restricted group found on service connection
+                if ($restrictedGroupsCount -gt 0) {
+                    $controlResult.AddMessage([VerificationResult]::Failed, "Count of broader groups that have excessive permissions on service connection: $($restrictedGroupsCount)")
+                    $backupDataObject = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} },@{l = 'Id'; e = { $_.Id} }, @{l = 'Role'; e = { $_.Role } },@{l = 'AccessDisplayName'; e = { $_.AccessDisplayName } }
+                    $formattedGroupsData = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} }, @{l = 'Role'; e = { $_.Role } },@{l = 'AccessDisplayName'; e = { $_.AccessDisplayName } }
+                    $formattedGroupsTable = ($formattedGroupsData | Out-String)
+                    $controlResult.AddMessage("`nList of groups: ", $formattedGroupsTable)
+                    $controlResult.SetStateData("List of groups: ", $formattedGroupsTable)
+                    $controlResult.AdditionalInfo += "Count of broader groups that have excessive permissions on service connection:  $($restrictedGroupsCount)";
+                    if ($this.ControlFixBackupRequired) {
+                        #Data object that will be required to fix the control
+                        $controlResult.BackupControlState = $backupDataObject;
                     }
-                    $roleAssignments +=   ($roleAssignmentsToCheck | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}},@{Name="Id"; Expression = {$_.identity.id}},@{Name="AccessDisplayName"; Expression = {$_.accessDisplayName}},@{Name="Role"; Expression = {$_.role.displayName}});
-                    #Checking where broader groups have user/admin permission for service connection
-                    $restrictedGroups += @($roleAssignments | Where-Object { $restrictedBroaderGroupsForSvcConn -contains $_.Name.split('\')[-1] -and ($_.Role -eq "Administrator" -or $_.Role -eq "User") })
-
-                    $restrictedGroupsCount = $restrictedGroups.Count
-
-                    # fail the control if restricted group found on service connection
-                    if ($restrictedGroupsCount -gt 0) {
-                        $controlResult.AddMessage([VerificationResult]::Failed, "Count of broader groups that have user/administrator access to service connection: $($restrictedGroupsCount)")
-                        $backupDataObject = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} },@{l = 'Id'; e = { $_.Id} }, @{l = 'Role'; e = { $_.Role } },@{l = 'AccessDisplayName'; e = { $_.AccessDisplayName } }
-                        $formattedGroupsData = $restrictedGroups | Select @{l = 'Group'; e = { $_.Name} }, @{l = 'Role'; e = { $_.Role } },@{l = 'AccessDisplayName'; e = { $_.AccessDisplayName } }
-                        $formattedGroupsTable = ($formattedGroupsData | Out-String)
-                        $controlResult.AddMessage("`nList of groups: ", $formattedGroupsTable)
-                        $controlResult.SetStateData("List of groups: ", $formattedGroupsTable)
-                        $controlResult.AdditionalInfo += "Count of broader groups that have user/administrator access to service connection:  $($restrictedGroupsCount)";
-                        if ($this.ControlFixBackupRequired) {
-                            #Data object that will be required to fix the control
-                            $controlResult.BackupControlState = $backupDataObject;
-                        }
-                        $restrictedGroupsAccess = $restrictedGroups | ForEach-Object { $_.Name + ': ' + $_.Role }
-                        $controlResult.AdditionalInfoInCSV = $restrictedGroupsAccess -join '; '
-                    }
-                    else {
-                        $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have user/administrator access to service connection.");
-                        $controlResult.AdditionalInfoInCSV = "NA";
-                    }
+                    $restrictedGroupsAccess = $restrictedGroups | ForEach-Object { $_.Name + ': ' + $_.Role }
+                    $controlResult.AdditionalInfoInCSV = $restrictedGroupsAccess -join '; '
                 }
                 else {
-                    $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have user/administrator access to service connection.");
+                    $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have excessive permissions on service connection.");
                     $controlResult.AdditionalInfoInCSV = "NA";
                 }
-                $controlResult.AddMessage("`nNote:`nThe following groups are considered 'broad' which should not have user/administrator privileges: `n$($restrictedBroaderGroupsForSvcConn | FT | out-string )`n");
-
             }
             else {
-                $controlResult.AddMessage([VerificationResult]::Error, "List of restricted broader groups for service connection is not defined in your organization policy. Please update your ControlSettings.json as per the latest AzSK.ADO PowerShell module.");
+                $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have excessive permissions on service connection.");
+                $controlResult.AdditionalInfoInCSV = "NA";
             }
+            $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+            $controlResult.AddMessage("`nNote:`nThe following groups are considered 'broad' which should not have excessive permissions: `n$($displayObj | FT | out-string -width 512)`n");
         }
-        catch {
-            $failMsg = $_
+        catch
+        {
+            $controlResult.AddMessage([VerificationResult]::Error, "Unable to fetch service connections details. Please verify from portal that you are not granting global security groups access to service connections");
             $controlResult.LogException($_)
-        }
-
-        if (![string]::IsNullOrEmpty($failMsg)) {
-            $controlResult.AddMessage([VerificationResult]::Error, "Unable to fetch service connections details. $($failMsg)Please verify from portal that you are not granting global security groups access to service connections");
         }
         return $controlResult;
     }

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.VariableGroup.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.VariableGroup.ps1
@@ -6,6 +6,7 @@ class VariableGroup: ADOSVTBase
     hidden [PSObject] $ProjectId;
     hidden [PSObject] $VarGrpId;
     hidden [string] $checkInheritedPermissionsPerVarGrp = $false
+    hidden [PSObject] $variableGroupIdentities = $null;
     VariableGroup([string] $organizationName, [SVTResource] $svtResource): Base($organizationName,$svtResource)
     {
         $this.ProjectId = ($this.ResourceContext.ResourceId -split "project/")[-1].Split('/')[0];
@@ -283,55 +284,60 @@ class VariableGroup: ADOSVTBase
     }
 
     hidden [ControlResult] CheckBroaderGroupAccess ([ControlResult] $controlResult) {
-
+    
         try {
             $controlResult.VerificationResult = [VerificationResult]::Failed
-            if ($this.ControlSettings -and [Helpers]::CheckMember($this.ControlSettings, "VariableGroup.RestrictedBroaderGroupsForVariableGroup") -and [Helpers]::CheckMember($this.ControlSettings, "VariableGroup.RestrictedRolesForBroaderGroupsInVariableGroup")) {
-                $restrictedBroaderGroupsForVarGrp = $this.ControlSettings.VariableGroup.RestrictedBroaderGroupsForVariableGroup;
-                $restrictedRolesForBroaderGroupsInvarGrp = $this.ControlSettings.VariableGroup.RestrictedRolesForBroaderGroupsInVariableGroup;
+            $restrictedBroaderGroups = @{}
+            $restrictedBroaderGroupsForVarGrp = $this.ControlSettings.VariableGroup.RestrictedBroaderGroupsForVariableGroup;
+            $restrictedBroaderGroupsForVarGrp.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
-                #Fetch variable group RBAC
-                $roleAssignments = @();
-
+            #Fetch variable group RBAC
+            $roleAssignments = @();
+            if ($null -eq $this.variableGroupIdentities) 
+            {
                 $url = 'https://dev.azure.com/{0}/_apis/securityroles/scopes/distributedtask.variablegroup/roleassignments/resources/{1}%24{2}?api-version=6.1-preview.1' -f $($this.OrganizationContext.OrganizationName), $($this.ProjectId), $($this.VarGrpId);
-                $responseObj = @([WebRequestHelper]::InvokeGetWebRequest($url));
-                if($responseObj.Count -gt 0)
-                {
-                    if ($this.checkInheritedPermissionsPerVarGrp -eq $false) {
-                        $responseObj = $responseObj  | where-object { $_.access -ne "inherited" }
-                    }
-                    $roleAssignments += ($responseObj  | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}},@{Name="Id"; Expression = {$_.identity.id}}, @{Name="Role"; Expression = {$_.role.displayName}});
+                $this.variableGroupIdentities = @([WebRequestHelper]::InvokeGetWebRequest($url));
+            }
+            if($this.variableGroupIdentities.Count -gt 0)
+            {
+                if ($this.checkInheritedPermissionsPerVarGrp -eq $false) {
+                    $roleAssignments = @($this.variableGroupIdentities  | where-object { $_.access -ne "inherited" })
                 }
+                $roleAssignments = @($roleAssignments  | Select-Object -Property @{Name="Name"; Expression = {$_.identity.displayName}},@{Name="Id"; Expression = {$_.identity.id}}, @{Name="Role"; Expression = {$_.role.displayName}});
+            }
 
-                # Checking whether the broader groups have User/Admin permissions
-                $backupDataObject = @($roleAssignments | Where-Object { ($restrictedBroaderGroupsForVarGrp -contains $_.Name.split('\')[-1]) -and  ($restrictedRolesForBroaderGroupsInvarGrp -contains $_.Role) })
-                
-                $restrictedGroups = @($backupDataObject | Select-Object Name,role)
-                $restrictedGroupsCount = $restrictedGroups.Count
+            # Checking whether the broader groups have User/Admin permissions
+            $backupDataObject = @($roleAssignments | Where-Object { ($restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1]) -and  ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]])})
+            $restrictedGroups = @($backupDataObject | Select-Object Name,role)
+            
+            if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $restrictedGroups.Count -gt 0)
+            {
+                $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($restrictedGroups, $true))
+                $restrictedGroups = @($restrictedGroups | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+            }
 
-                # fail the control if restricted group found on variable group
-                if ($restrictedGroupsCount -gt 0) {
-                    $controlResult.AddMessage([VerificationResult]::Failed, "`nCount of broader groups that have administrator access to variable group: $($restrictedGroupsCount)");
-                    $controlResult.AddMessage("`nList of groups: ")
-                    $controlResult.AddMessage(($restrictedGroups | FT Name,Role -AutoSize | Out-String -Width 512));
-                    $controlResult.SetStateData("List of groups: ", $restrictedGroups)
-                    $controlResult.AdditionalInfo += "Count of broader groups that have administrator access to variable group: $($restrictedGroupsCount)";
-                    if ($this.ControlFixBackupRequired) {
-                        #Data object that will be required to fix the control
-                        $controlResult.BackupControlState = $backupDataObject;
-                    }
-                    $formatedRestrictedGroups = $restrictedGroups | ForEach-Object { $_.Name + ': ' + $_.Role }
-                    $controlResult.AdditionalInfoInCSV = ($formatedRestrictedGroups -join '; ' )
+            $restrictedGroupsCount = $restrictedGroups.Count
+
+            # fail the control if restricted group found on variable group
+            if ($restrictedGroupsCount -gt 0) {
+                $controlResult.AddMessage([VerificationResult]::Failed, "`nCount of broader groups that have excessive permissions on variable group: $($restrictedGroupsCount)");
+                $controlResult.AddMessage("`nList of groups: ")
+                $controlResult.AddMessage(($restrictedGroups | FT Name,Role -AutoSize | Out-String -Width 512));
+                $controlResult.SetStateData("List of groups: ", $restrictedGroups)
+                $controlResult.AdditionalInfo += "Count of broader groups that have excessive permissions on variable group: $($restrictedGroupsCount)";
+                if ($this.ControlFixBackupRequired) {
+                    #Data object that will be required to fix the control
+                    $controlResult.BackupControlState = $backupDataObject;
                 }
-                else {
-                    $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have administrator access to variable group.");
-                    $controlResult.AdditionalInfoInCSV += "NA"
-                }
-                $controlResult.AddMessage("Note:`nThe following groups are considered 'broad' and should not have administrator privileges: `n$( $restrictedBroaderGroupsForVarGrp| FT | out-string)");
+                $formatedRestrictedGroups = $restrictedGroups | ForEach-Object { $_.Name + ': ' + $_.Role }
+                $controlResult.AdditionalInfoInCSV = ($formatedRestrictedGroups -join '; ' )
             }
             else {
-                $controlResult.AddMessage([VerificationResult]::Error, "List of restricted broader groups and restricted roles for variable group is not defined in the control settings for your organization policy.");
+                $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have excessive permissions on variable group.");
+                $controlResult.AdditionalInfoInCSV += "NA"
             }
+            $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+            $controlResult.AddMessage("Note:`nThe following groups are considered 'broad' and should not have excessive permissions: `n$( $displayObj| FT | out-string)");
         }
         catch {
             $controlResult.AddMessage([VerificationResult]::Error, "Could not fetch the variable group permissions.");
@@ -401,10 +407,11 @@ class VariableGroup: ADOSVTBase
         $controlResult.VerificationResult = [VerificationResult]::Failed;
         try 
         {
-            if ($this.ControlSettings -and [Helpers]::CheckMember($this.ControlSettings, "VariableGroup.RestrictedBroaderGroupsForVariableGroup") -and [Helpers]::CheckMember($this.ControlSettings, "VariableGroup.RestrictedRolesForBroaderGroupsInVariableGroupContainingSecrets"))
+            if ($this.ControlSettings -and [Helpers]::CheckMember($this.ControlSettings, "VariableGroup.RestrictedBroaderGroupsForVariableGroup"))
             {
+                $restrictedBroaderGroups = @{}
                 $restrictedBroaderGroupsForVarGrp = $this.ControlSettings.VariableGroup.RestrictedBroaderGroupsForVariableGroup;
-                $restrictedRolesForBroaderGroupsInvarGrp = $this.ControlSettings.VariableGroup.RestrictedRolesForBroaderGroupsInVariableGroupContainingSecrets;
+                $restrictedBroaderGroupsForVarGrp.psobject.properties | foreach { $restrictedBroaderGroups[$_.Name] = $_.Value }
 
                 if([Helpers]::CheckMember($this.VarGrp[0],"variables"))
                 {
@@ -449,7 +456,14 @@ class VariableGroup: ADOSVTBase
                         }
 
                         # Checking whether the broader groups have User/Admin permissions
-                        $restrictedGroups = @($roleAssignments | Where-Object { ($restrictedBroaderGroupsForVarGrp -contains $_.Name.split('\')[-1]) -and  ($restrictedRolesForBroaderGroupsInvarGrp -contains $_.Role) })
+                        $restrictedGroups = @($roleAssignments | Where-Object { ($restrictedBroaderGroups.keys -contains $_.Name.split('\')[-1]) -and ($_.Role -in $restrictedBroaderGroups[$_.Name.split('\')[-1]])})
+
+                        if ($this.ControlSettings.CheckForBroadGroupMemberCount -and $restrictedGroups.Count -gt 0)
+                        {
+                            $broaderGroupsWithExcessiveMembers = @([ControlHelper]::FilterBroadGroupMembers($restrictedGroups, $true))
+                            $restrictedGroups = @($restrictedGroups | Where-Object {$broaderGroupsWithExcessiveMembers -contains $_.Name})
+                        }
+
                         $restrictedGroupsCount = $restrictedGroups.Count
 
                         # fail the control if restricted group found on variable group which contains secrets
@@ -473,11 +487,11 @@ class VariableGroup: ADOSVTBase
                         }
                         else
                         {
-                            $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have user/administrator access to variable group.");
+                            $controlResult.AddMessage([VerificationResult]::Passed, "No broader groups have excessive permissions on the variable group.");
                             $controlResult.AdditionalInfoInCSV += "NA"
                         }
-
-                        $controlResult.AddMessage("`nNote:`nThe following groups are considered 'broad' and should not have user/administrator privileges: `n$( $restrictedBroaderGroupsForVarGrp| FT | out-string)");
+                        $displayObj = $restrictedBroaderGroups.Keys | Select-Object @{Name = "Broader Group"; Expression = {$_}}, @{Name = "Excessive Permissions"; Expression = {$restrictedBroaderGroups[$_] -join ', '}}
+                        $controlResult.AddMessage("`nNote:`nThe following groups are considered 'broad' and should not have excessive permissions: `n$( $displayObj| FT | out-string -Width 512)");
                     }
                     else
                     {

--- a/src/AzSK.ADO/Framework/Helpers/ControlHelper.ps1
+++ b/src/AzSK.ADO/Framework/Helpers/ControlHelper.ps1
@@ -3,6 +3,14 @@ class ControlHelper: EventBase{
 
     static [psobject] $ControlFixBackup = @()
     static $GroupMembersResolutionObj = @{} #Caching group resolution
+    static $ResolvedBroaderGroups = @{} # Caching expanded broader groups
+    static $GroupsWithNumerousMembers = @() # Groups which contains very large groups
+    static $VeryLargeGroups = @() # Very large groups (fetched from controlsettings)
+    static $IsGroupDetailsFetchedFromPolicy = $false
+    static $AllowedMemberCountPerBroadGroup = @() # Allowed member count (fetched from controlsettings)
+    static $GroupsToExpand = @() # Groups for which meber counts need to check (fetched from controlsettings)
+    static $GroupsWithDescriptor = @{} # All broder groups with descriptors
+    static [string] $parentGroup = $null #used to store current broader group
       
     #Checks if the severities passed by user are valid and filter out invalid ones
    hidden static [string []] CheckValidSeverities([string []] $ParamSeverities)
@@ -132,4 +140,169 @@ class ControlHelper: EventBase{
 
         [ControlHelper]::ResolveNestedGroupMembers($descriptor, $orgName, $projName)
     }
+
+    static [PSObject] ResolveNestedBroaderGroupMembers([PSObject]$groupObj,[string] $orgName,[string] $projName)
+    {
+        $groupPrincipalName = $groupObj.principalName
+        $members = @()
+        if ([ControlHelper]::ResolvedBroaderGroups.ContainsKey($groupPrincipalName))
+        {
+            $members += [ControlHelper]::ResolvedBroaderGroups[$_.principalName];
+            return $members
+        }
+        else
+        {
+            [ControlHelper]::ResolvedBroaderGroups[$groupPrincipalName] = @()
+            $rmContext = [ContextHelper]::GetCurrentContext();
+            $user = "";
+            $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $user,$rmContext.AccessToken)))
+            $memberslist = @()
+            if ([string]::IsNullOrWhiteSpace($groupObj.descriptor) -and (-not [string]::IsNullOrWhiteSpace($groupObj.entityId)))
+            {
+                $apiUrl = 'https://dev.azure.com/{0}/_apis/IdentityPicker/Identities/{1}/connections?identityTypes=user&identityTypes=group&operationScopes=ims&operationScopes=source&connectionTypes=successors&depth=1&properties=DisplayName&properties=SubjectDescriptor&properties=SignInAddress' -f $($OrgName), $($groupObj.entityId)
+                $responseObj = @(Invoke-RestMethod -Method Get -Uri $apiURL -Headers @{Authorization = ("Basic {0}" -f $base64AuthInfo) } -UseBasicParsing)
+                # successors property will not be available if there are no users added to group.
+                if ([Helpers]::CheckMember($responseObj[0], "successors")) {
+                    $memberslist = @($responseObj.successors | Select-Object entityId, originId, descriptor, @{Name = "principalName"; Expression = { $_.displayName } }, @{Name = "mailAddress"; Expression = { $_.signInAddress } }, @{Name = "subjectKind"; Expression = { $_.entityType } })
+                }
+                $members += [ControlHelper]::NestedGroupResolverHelper($memberslist)
+            }
+            else
+            {
+                $descriptor = $groupObj.descriptor
+                $url="https://dev.azure.com/{0}/_apis/Contribution/HierarchyQuery?api-version=5.1-preview" -f $($orgName);
+                $postbody=@'
+                {"contributionIds":["ms.vss-admin-web.org-admin-members-data-provider"],"dataProviderContext":{"properties":{"subjectDescriptor":"{0}","sourcePage":{"url":"https://dev.azure.com/{1}/{2}/_settings/permissions?subjectDescriptor={0}","routeId":"ms.vss-admin-web.collection-admin-hub-route","routeValues":{"adminPivot":"groups","controller":"ContributedPage","action":"Execute"}}}}}
+'@
+                $postbody=$postbody.Replace("{0}",$descriptor)
+                $postbody=$postbody.Replace("{1}",$orgName)
+                $postbody=$postbody.Replace("{2}",$projName)
+                $response = Invoke-RestMethod -Uri $url -Method Post -ContentType "application/json" -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -Body $postbody
+                if([Helpers]::CheckMember($response.dataProviders.'ms.vss-admin-web.org-admin-members-data-provider', "identities"))
+                {
+                    $memberslist = @($response.dataProviders.'ms.vss-admin-web.org-admin-members-data-provider'.identities)
+                }
+                $members += [ControlHelper]::NestedGroupResolverHelper($memberslist)
+            }
+
+            [ControlHelper]::ResolvedBroaderGroups[$groupPrincipalName] = $members
+            return $members
+        }
+    }
+
+    static [PSObject] NestedGroupResolverHelper($memberslist)
+    {
+        $members = @()
+        if ($memberslist.Count -gt 0) 
+        {
+            $memberslist | ForEach-Object {
+                if($_.subjectKind -eq "Group")
+                {
+                    if ([ControlHelper]::VeryLargeGroups -contains $_.principalName) {
+                        [ControlHelper]::GroupsWithNumerousMembers += [ControlHelper]::parentGroup
+                    }
+                    else
+                    {
+                        $members += [ControlHelper]::ResolveNestedBroaderGroupMembers($_, $orgName, $projName)
+                        Write-Host "Group: [$($_.principalName)]; MemberCount: $([ControlHelper]::ResolvedBroaderGroups[$_.principalName].Count)" -ForegroundColor Cyan
+                    }
+                }
+                else
+                {
+                    $members += $_
+                }
+            }
+        }
+        return $members
+    }
+
+    static [PSObject] GetBroaderGroupDescriptorObj([string] $OrgName,[string] $groupName)
+    {
+        $groupObj = @()
+        $projName = $groupName.Split("\")[0] -replace '[\[\]]'
+        $rmContext = [ContextHelper]::GetCurrentContext();
+		$user = "";
+        $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $user,$rmContext.AccessToken)))
+        $url= "https://dev.azure.com/{0}/_apis/Contribution/HierarchyQuery?api-version=5.1-preview.1" -f $($OrgName);
+
+        if ($projName -eq $OrgName) {
+            $body=@'
+            {"contributionIds":["ms.vss-admin-web.org-admin-groups-data-provider"],"dataProviderContext":{"properties":{"sourcePage":{"url":"https://dev.azure.com/{0}/_settings/groups","routeId":"ms.vss-admin-web.collection-admin-hub-route","routeValues":{"adminPivot":"groups","controller":"ContributedPage","action":"Execute"}}}}}
+'@
+            $body=$body.Replace("{0}",$OrgName)
+        }
+        else {
+            $body=@'
+            {"contributionIds":["ms.vss-admin-web.org-admin-groups-data-provider"],"dataProviderContext":{"properties":{"sourcePage":{"url":"https://dev.azure.com/{0}/{1}/_settings/permissions","routeId":"ms.vss-admin-web.project-admin-hub-route","routeValues":{"project":"{1}","adminPivot":"permissions","controller":"ContributedPage","action":"Execute"}}}}}
+'@
+            $body=$body.Replace("{0}",$OrgName)
+            $body=$body.Replace("{1}",$projName)
+        }
+        
+        try{
+            $responseObj = Invoke-RestMethod -Uri $url -Method Post -ContentType "application/json" -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -Body $body
+            $groupObj = $responseObj.dataProviders.'ms.vss-admin-web.org-admin-groups-data-provider'.identities | Where-Object {$_.principalName -eq $groupName}
+        }
+        catch {
+            Write-Host $_
+        }
+        return $groupObj
+    }
+
+    hidden static FetchControlSettingDetails()
+    {
+        $ControlSettingsObj = [ConfigurationManager]::LoadServerConfigFile("ControlSettings.json");
+        [ControlHelper]::VeryLargeGroups = @($ControlSettingsObj.VeryLargeGroups)
+        [ControlHelper]::AllowedMemberCountPerBroadGroup = @($ControlSettingsObj.AllowedMemberCountPerBroadGroup)
+        [ControlHelper]::GroupsToExpand = @($ControlSettingsObj.BroaderGroupsToExpand)
+        [ControlHelper]::IsGroupDetailsFetchedFromPolicy = $true
+    }
+
+    static [PSObject] FilterBroadGroupMembers([PSObject] $groupList, [bool] $fetchDescriptor)
+    {
+        $broaderGroupsWithExcessiveMembers = @()
+        if ([ControlHelper]::IsGroupDetailsFetchedFromPolicy -eq $false) {
+            [ControlHelper]::FetchControlSettingDetails()
+        }
+        $groupList | Foreach-Object {
+            # In some cases, group object doesn't contains descriptor key which requires to expand the groups.
+            if ($fetchDescriptor) {
+                if (-not ([ControlHelper]::GroupsWithDescriptor.keys -contains $_.Name)) {
+                    [ControlHelper]::GroupsWithDescriptor[$_.Name] += [ControlHelper]::GetBroaderGroupDescriptorObj($this.OrganizationContext.OrganizationName, $_.Name)
+                }
+                $groupObj = [ControlHelper]::GroupsWithDescriptor[$_.Name]
+            }
+            else {
+                $groupObj = $_
+            }
+            $groupName = $groupObj.principalName.split('\')[-1]
+            if ([ControlHelper]::GroupsToExpand -contains $groupName) 
+            {
+                [ControlHelper]::parentGroup = $groupObj.principalName
+                if (-not [ControlHelper]::ResolvedBroaderGroups.ContainsKey($groupObj.principalName)) {
+                    $groupMembers = @([ControlHelper]::ResolveNestedBroaderGroupMembers($groupObj, $this.OrganizationContext.OrganizationName, $this.ResourceContext.ResourceGroupName))
+                }
+                else {
+                    $groupMembers = @([ControlHelper]::ResolvedBroaderGroups[$groupObj.principalName])
+                }
+                $groupMembersCount = @($groupMembers | Select-Object -property mailAddress -Unique).Count
+                if ([Helpers]::CheckMember([ControlHelper]::AllowedMemberCountPerBroadGroup, $groupName))
+                {
+                    $allowedMemberCount = [ControlHelper]::AllowedMemberCountPerBroadGroup.$groupName
+                    if (($groupMembersCount -gt $allowedMemberCount) -or ([ControlHelper]::GroupsWithNumerousMembers -contains $groupObj.principalName))
+                    {
+                        $broaderGroupsWithExcessiveMembers += $groupObj.principalName
+                    }
+                }
+                else {
+                    $broaderGroupsWithExcessiveMembers += $groupObj.principalName
+                }
+            }
+            else
+            {
+                $broaderGroupsWithExcessiveMembers += $groupObj.principalName
+            }
+        }
+        return $broaderGroupsWithExcessiveMembers
+    } 
 }


### PR DESCRIPTION
## Updated following controls

1. ADO_AgentPool_AuthZ_Restrict_Broader_Group_Access
2. ADO_Build_AuthZ_Restrict_Broader_Group_Access
3. ADO_Feed_AuthZ_Restrict_Broader_Group_Access
4. ADO_SecureFile_AuthZ_Restrict_Broader_Group_Access
5. ADO_Environment_AuthZ_Restrict_Broader_Group_Access
6. ADO_Release_AuthZ_Restrict_Broader_Group_Access
7. ADO_ServiceConnection_AuthZ_Restrict_Broader_Group_Access
8. ADO_VariableGroup_AuthZ_Restrict_Broader_Group_Access
9. ADO_VariableGroup_AuthZ_Restrict_Broader_Group_Access_On_VG_With_Secrets
10. ADO_Project_AuthZ_Restrict_Broader_Group_Access_on_Agentpool
11. ADO_Project_AuthZ_Restrict_Broader_Group_Access_on_Builds
12. ADO_Project_AuthZ_Restrict_Broader_Group_Access_on_SecureFile
13. ADO_Project_AuthZ_Restrict_Broader_Group_Access_on_Env
14. ADO_Project_AuthZ_Restrict_Broader_Group_Access_on_Releases
15. ADO_Project_AuthZ_Restrict_Broader_Group_Access_on_SvcConn
16. ADO_Project_AuthZ_Restrict_Broader_Group_Access_on_VarGrp

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
