### PR TITLE
Implemented two controls for agent pool.

### DIFF
--- a/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.AgentPool.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.AgentPool.json
@@ -162,6 +162,40 @@
         "AutomatedFix"
       ],
       "Enabled": true
+    },
+    {
+      "ControlID": "ADO_AgentPool_AuthZ_Enable_Branch_Control",
+      "Description": "Allow agent pools to be accessed only by select branches.",
+      "Id": "AgentPool210",
+      "ControlSeverity": "Medium",
+      "Automated": "Yes",
+      "MethodName": "CheckBranchControlForAgentPool",
+      "Rationale": "Once a agent pool is made accessible to a YAML pipeline, malicious users with 'create branch' permissions on the repository will be able to access the agent pool by queueing the pipeline from the branch they select even if they do not have access to the agent pool. To prevent this ensure that the agent pool can be accessed only from select branches (eg. 'main').",
+      "Recommendation": "1. Go to Project Settings --> 2. Pipelines --> 3. Agent pools --> 4. Select your agent pool --> 5. Select Approvals and Checks --> 6. Click on 'Branch Control' --> Create a branch control --> Provide the branches from which you would like the agent pool to be accessed from. For additional protection, enable 'Verify branch protection'.",
+      "Tags": [
+        "SDL",
+        "TCP",
+        "Automated",
+        "AuthZ"
+      ],
+      "Enabled": true
+    },
+    {
+      "ControlID": "ADO_AgentPool_DP_Use_Template_From_Protected_Branch",
+      "Description": "Allow agent pools to be accessed by templates only from protected branches.",
+      "Id": "AgentPool220",
+      "ControlSeverity": "Medium",
+      "Automated": "Yes",
+      "MethodName": "CheckTemplateBranchForAgentPool",
+      "Rationale": "If malicious users have 'contribute' permissions to the repository containing the template required to access the agent pool, they can tamper the template itself and misuse the service connection. To prevent this, enable branch protection policies on the branch which contains the template required to access this resource.",
+      "Recommendation": "1. Go to Project Settings --> 2. Pipelines --> 3. Agent pools --> 4. Select your agent pool --> 5. Select Approvals and checks --> 6. Click on 'See All' --> 7. Select Required Template --> 8. Click on 'Next' --> 9.Add required YAML template -->  Provide the repository, ref and the path to required YAML template.",
+      "Tags": [
+        "SDL",
+        "TCP",
+        "Automated",
+        "DP"
+      ],
+      "Enabled": true
     }
 
   ]

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.AgentPool.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.AgentPool.json
@@ -170,7 +170,7 @@
       "ControlSeverity": "Medium",
       "Automated": "Yes",
       "MethodName": "CheckBranchControlForAgentPool",
-      "Rationale": "Once a agent pool is made accessible to a YAML pipeline, malicious users with 'create branch' permissions on the repository will be able to access the agent pool by queueing the pipeline from the branch they select even if they do not have access to the agent pool. To prevent this ensure that the agent pool can be accessed only from select branches (eg. 'main').",
+      "Rationale": "Once an agent pool is made accessible to a YAML pipeline, malicious users with 'create branch' permissions on the repository will be able to access the agent pool by queueing the pipeline from the branch they select even if they do not have access to the agent pool. To prevent this ensure that the agent pool can be accessed only from select branches (e.g., 'main').",
       "Recommendation": "1. Go to Project Settings --> 2. Pipelines --> 3. Agent pools --> 4. Select your agent pool --> 5. Select Approvals and Checks --> 6. Click on 'Branch Control' --> Create a branch control --> Provide the branches from which you would like the agent pool to be accessed from. For additional protection, enable 'Verify branch protection'.",
       "Tags": [
         "SDL",

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -415,7 +415,8 @@
         "User"
       ]
     },
-    "CheckForInheritedPermissions": false
+    "CheckForInheritedPermissions": false,
+    "CheckForBranchProtection":true
   },
   "VariableGroup": {
     "VariableGroupHistoryPeriodInDays": 180,


### PR DESCRIPTION
## Description
</br>
 Brief description of the requested change.
The two controls are:
1. ADO_AgentPool_AuthZ_Enable_Branch_Control : Allow agent pools to be accessed only by select branches.
2. ADO_AgentPool_DP_Use_Template_From_Protected_Branch : Allow agent pools to be accessed by templates only from protected branches.

## Checklist
- [ ] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [ ] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [ ] The title of the PR clearly describes the intent of the PR.
- [ ] This PR does not introduce any breaking changes to the code.
