### PR TITLE
Revised permissions on Broader group access

### DIFF
--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -291,29 +291,50 @@
         "Environment",
         "SolutionName"
     ],
-    "RestrictedBroaderGroupsForBuild" : {
-      "Contributors":[
+    "RestrictedBroaderGroupsForBuild": {
+
+      "Contributors": [
+        "Retain indefinitely",
+        "Manage build qualities",
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
         "Destroy builds",
         "Edit build pipeline"
       ],
-      "Readers":[
+      "Readers": [
+        "Retain indefinitely",
+        "Manage build qualities",
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
         "Destroy builds",
         "Edit build pipeline"
       ],
-      "Project Collection Valid Users":[
+      "Project Collection Valid Users": [
+        "Retain indefinitely",
+        "Manage build qualities",
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
         "Destroy builds",
         "Edit build pipeline"
       ],
-      "Project Valid Users":[
+      "Project Valid Users": [
+        "Retain indefinitely",
+        "Manage build qualities",
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -354,41 +375,55 @@
         "BuildConfiguration"
     ],
     "RestrictedBroaderGroupsForRelease" : {
-      "Contributors":[
+      "Contributors": [
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",      
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
-      "Readers":[
+      "Readers": [
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Edit release pipeline",
-        "Delete release stage",      
-        "Edit release stage",
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
-      "Project Collection Valid Users":[
+      "Project Collection Valid Users": [
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Edit release pipeline",
-        "Delete release stage",      
-        "Edit release stage",
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Valid Users":[
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Edit release pipeline",
-        "Delete release stage",      
-        "Edit release stage",
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ]
@@ -641,43 +676,51 @@
       "*@microsoftfederal.com"
     ],
     "RestrictedBroaderGroupsForRepo" : {
-      "Contributors":[
-        "Delete repository",
-        "Manage permissions",
-        "Bypass policies when completing pull requests",
-        "Bypass policies when pushing",
-        "Edit policies",
-        "Force push (rewrite history, delete branches and tags)"
-      ],
-      "Readers":[
-        "Contribute",
-        "Delete repository",
+      "Contributors": [
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Rename repository"
+        "Policy exempt for push",
+        "Remove others' locks"
       ],
-      "Project Collection Valid Users":[
+      "Readers": [
         "Contribute",
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Rename repository"
+        "Rename repository",
+        "Policy exempt for push",
+        "Remove others' locks"
       ],
-      "Project Valid Users":[
+      "Project Collection Valid Users": [
         "Contribute",
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Rename repository"
+        "Rename repository",
+        "Policy exempt for push",
+        "Remove others' locks"
+      ],
+      "Project Valid Users": [
+        "Contribute",
+        "Delete or disable repository",
+        "Manage permissions",
+        "Bypass policies when completing pull requests",
+        "Bypass policies when pushing",
+        "Edit policies",
+        "Force push (rewrite history, delete branches and tags)",
+        "Rename repository",
+        "Policy exempt for push",
+        "Remove others' locks"
       ]
     },
     "RestrictedBroaderGroupsForApproversForRepo": [

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -294,8 +294,6 @@
     "RestrictedBroaderGroupsForBuild": {
 
       "Contributors": [
-        "Retain indefinitely",
-        "Manage build qualities",
         "Manage build queue",
         "Stop builds",
         "Override build checkIn validation",
@@ -306,8 +304,6 @@
         "Edit build pipeline"
       ],
       "Readers": [
-        "Retain indefinitely",
-        "Manage build qualities",
         "Manage build queue",
         "Stop builds",
         "Override build checkIn validation",
@@ -318,8 +314,6 @@
         "Edit build pipeline"
       ],
       "Project Collection Valid Users": [
-        "Retain indefinitely",
-        "Manage build qualities",
         "Manage build queue",
         "Stop builds",
         "Override build checkIn validation",
@@ -330,8 +324,6 @@
         "Edit build pipeline"
       ],
       "Project Valid Users": [
-        "Retain indefinitely",
-        "Manage build qualities",
         "Manage build queue",
         "Stop builds",
         "Override build checkIn validation",

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
@@ -1875,6 +1875,7 @@ class Build: ADOSVTBase
         }
 
         return $controlResult;
+        
     }
 
     hidden [ControlResult] CheckBroaderGroupAccessAutomatedFix([ControlResult] $controlResult)

--- a/src/oss-config-preview/1.0.0/ControlSettings.json
+++ b/src/oss-config-preview/1.0.0/ControlSettings.json
@@ -293,6 +293,9 @@
     ],
     "RestrictedBroaderGroupsForBuild" : {
       "Contributors":[
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -300,6 +303,9 @@
         "Edit build pipeline"
       ],
       "Readers":[
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -307,6 +313,9 @@
         "Edit build pipeline"
       ],
       "Project Collection Valid Users":[
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -314,6 +323,9 @@
         "Edit build pipeline"
       ],
       "Project Valid Users":[
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -355,40 +367,54 @@
     ],
     "RestrictedBroaderGroupsForRelease" : {
       "Contributors":[
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",      
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Readers":[
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Edit release pipeline",
-        "Delete release stage",      
-        "Edit release stage",
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Collection Valid Users":[
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Edit release pipeline",
-        "Delete release stage",      
-        "Edit release stage",
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Valid Users":[
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Edit release pipeline",
-        "Delete release stage",      
-        "Edit release stage",
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ]
@@ -642,42 +668,50 @@
     ],
     "RestrictedBroaderGroupsForRepo" : {
       "Contributors":[
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
-        "Force push (rewrite history, delete branches and tags)"
+        "Force push (rewrite history, delete branches and tags)",
+        "Policy exempt for push",
+        "Remove others' locks"
       ],
       "Readers":[
         "Contribute",
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Rename repository"
+        "Rename repository",
+        "Policy exempt for push",
+        "Remove others' locks"
       ],
       "Project Collection Valid Users":[
         "Contribute",
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Rename repository"
+        "Rename repository",
+        "Policy exempt for push",
+        "Remove others' locks"
       ],
       "Project Valid Users":[
         "Contribute",
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Rename repository"
+        "Rename repository",
+        "Policy exempt for push",
+        "Remove others' locks"
       ]
     },
     "RestrictedBroaderGroupsForApproversForRepo": [
@@ -891,8 +925,8 @@
         "ADO_Build_SI_Dont_Use_Broadly_Editable_Variable_Group",
         "ADO_Build_DP_Dont_Make_Secrets_Available_To_Forked_Builds",
         "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time"
-      ]
-    
+      ]  
+
     },
     {
       "ResourceType":"Release",
@@ -901,8 +935,8 @@
         "ADO_Release_SI_Dont_Use_Broadly_Editable_Task_Group",
         "ADO_Release_SI_Dont_Use_Broadly_Editable_Variable_Group",
         "ADO_Release_SI_Review_URL_Variables_Settable_At_Release_Time"
-    ]
-        
+    ] 
+
     },
     {
       "ResourceType":"ServiceConnection",
@@ -910,8 +944,8 @@
         "ADO_ServiceConnection_AuthZ_Restrict_Broader_Group_Access",
         "ADO_ServiceConnection_AuthZ_Dont_Grant_BuildSvcAcct_Permission",
         "ADO_ServiceConnection_AuthZ_Dont_Grant_All_Pipelines_Access"
-    ]
-        
+    ]      
+
     },
     {
       "ResourceType": "AgentPool",

--- a/src/oss-config/1.0.0/ControlSettings.json
+++ b/src/oss-config/1.0.0/ControlSettings.json
@@ -293,6 +293,9 @@
     ],
     "RestrictedBroaderGroupsForBuild" : {
       "Contributors":[
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -300,6 +303,9 @@
         "Edit build pipeline"
       ],
       "Readers":[
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -307,6 +313,9 @@
         "Edit build pipeline"
       ],
       "Project Collection Valid Users":[
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -314,6 +323,9 @@
         "Edit build pipeline"
       ],
       "Project Valid Users":[
+        "Manage build queue",
+        "Stop builds",
+        "Override build checkIn validation",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -355,40 +367,54 @@
     ],
     "RestrictedBroaderGroupsForRelease" : {
       "Contributors":[
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",      
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Readers":[
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Edit release pipeline",
-        "Delete release stage",      
-        "Edit release stage",
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Collection Valid Users":[
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Edit release pipeline",
-        "Delete release stage",      
-        "Edit release stage",
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Valid Users":[
+        "Edit release pipeline",
+        "Delete release definition",
+        "Edit release stage",
+        "Delete release stage",
+        "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Edit release pipeline",
-        "Delete release stage",      
-        "Edit release stage",
+        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ]
@@ -642,42 +668,50 @@
     ],
     "RestrictedBroaderGroupsForRepo" : {
       "Contributors":[
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
-        "Force push (rewrite history, delete branches and tags)"
+        "Force push (rewrite history, delete branches and tags)",
+        "Policy exempt for push",
+        "Remove others' locks"
       ],
       "Readers":[
         "Contribute",
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Rename repository"
+        "Rename repository",
+        "Policy exempt for push",
+        "Remove others' locks"
       ],
       "Project Collection Valid Users":[
         "Contribute",
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Rename repository"
+        "Rename repository",
+        "Policy exempt for push",
+        "Remove others' locks"
       ],
       "Project Valid Users":[
         "Contribute",
-        "Delete repository",
+        "Delete or disable repository",
         "Manage permissions",
         "Bypass policies when completing pull requests",
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Rename repository"
+        "Rename repository",
+        "Policy exempt for push",
+        "Remove others' locks"
       ]
     },
     "RestrictedBroaderGroupsForApproversForRepo": [
@@ -891,7 +925,7 @@
         "ADO_Build_SI_Dont_Use_Broadly_Editable_Variable_Group",
         "ADO_Build_DP_Dont_Make_Secrets_Available_To_Forked_Builds",
         "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time"
-      ]
+      ]  
     },
     {
       "ResourceType":"Release",
@@ -900,7 +934,7 @@
         "ADO_Release_SI_Dont_Use_Broadly_Editable_Task_Group",
         "ADO_Release_SI_Dont_Use_Broadly_Editable_Variable_Group",
         "ADO_Release_SI_Review_URL_Variables_Settable_At_Release_Time"
-      ]   
+    ] 
     },
     {
       "ResourceType":"ServiceConnection",
@@ -908,7 +942,7 @@
         "ADO_ServiceConnection_AuthZ_Restrict_Broader_Group_Access",
         "ADO_ServiceConnection_AuthZ_Dont_Grant_BuildSvcAcct_Permission",
         "ADO_ServiceConnection_AuthZ_Dont_Grant_All_Pipelines_Access"
-      ]   
+    ]      
     },
     {
       "ResourceType": "AgentPool",


### PR DESCRIPTION
## Description
</br>
Summary: ADO Powershell module has controls related to reviewing broader group access against set of permissions.

These permissions were identified long and there is a need to revisit again to update the permission. The below are the controls we identified to revisit.

ADO_Release_AuthZ_Restrict_Broader_Group_Access
ADO_Build_AuthZ_Restrict_Broader_Group_Access

[Control_Details_AzSK.ADO_1.20.0.csv](https://github.com/dsr-microsoft/DevOps-Security-Scanners/files/14220583/Control_Details_AzSK.ADO_1.20.0.csv)

## Checklist
- [x] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [x] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [x] The title of the PR clearly describes the intent of the PR.
- [x] This PR does not introduce any breaking changes to the code.
