### PR TITLE
Updated the changes for broader access setting

### DIFF
--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -296,7 +296,7 @@
       "Contributors": [
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -306,7 +306,7 @@
       "Readers": [
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -316,7 +316,7 @@
       "Project Collection Valid Users": [
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -326,7 +326,7 @@
       "Project Valid Users": [
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -369,53 +369,45 @@
     "RestrictedBroaderGroupsForRelease" : {
       "Contributors": [
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Readers": [
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Collection Valid Users": [
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Valid Users":[
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ]
@@ -675,8 +667,8 @@
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Policy exempt for push",
-        "Remove others' locks"
+        "Remove others' locks",
+        "Rename repository"
       ],
       "Readers": [
         "Contribute",
@@ -687,7 +679,6 @@
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
         "Rename repository",
-        "Policy exempt for push",
         "Remove others' locks"
       ],
       "Project Collection Valid Users": [
@@ -699,7 +690,6 @@
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
         "Rename repository",
-        "Policy exempt for push",
         "Remove others' locks"
       ],
       "Project Valid Users": [
@@ -711,7 +701,6 @@
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
         "Rename repository",
-        "Policy exempt for push",
         "Remove others' locks"
       ]
     },

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
@@ -1875,7 +1875,6 @@ class Build: ADOSVTBase
         }
 
         return $controlResult;
-        
     }
 
     hidden [ControlResult] CheckBroaderGroupAccessAutomatedFix([ControlResult] $controlResult)

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
@@ -1875,6 +1875,7 @@ class Build: ADOSVTBase
         }
 
         return $controlResult;
+        
     }
 
     hidden [ControlResult] CheckBroaderGroupAccessAutomatedFix([ControlResult] $controlResult)

--- a/src/oss-config-preview/1.0.0/ControlSettings.json
+++ b/src/oss-config-preview/1.0.0/ControlSettings.json
@@ -292,10 +292,10 @@
         "SolutionName"
     ],
     "RestrictedBroaderGroupsForBuild" : {
-      "Contributors":[
+"Contributors":[
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -305,7 +305,7 @@
       "Readers":[
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -315,7 +315,7 @@
       "Project Collection Valid Users":[
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -325,7 +325,7 @@
       "Project Valid Users":[
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -368,53 +368,45 @@
     "RestrictedBroaderGroupsForRelease" : {
       "Contributors":[
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Readers":[
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Collection Valid Users":[
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Valid Users":[
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ]
@@ -674,8 +666,8 @@
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Policy exempt for push",
-        "Remove others' locks"
+        "Remove others' locks",
+        "Rename repository"
       ],
       "Readers":[
         "Contribute",
@@ -686,7 +678,6 @@
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
         "Rename repository",
-        "Policy exempt for push",
         "Remove others' locks"
       ],
       "Project Collection Valid Users":[
@@ -698,7 +689,6 @@
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
         "Rename repository",
-        "Policy exempt for push",
         "Remove others' locks"
       ],
       "Project Valid Users":[
@@ -710,7 +700,6 @@
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
         "Rename repository",
-        "Policy exempt for push",
         "Remove others' locks"
       ]
     },

--- a/src/oss-config/1.0.0/ControlSettings.json
+++ b/src/oss-config/1.0.0/ControlSettings.json
@@ -292,10 +292,10 @@
         "SolutionName"
     ],
     "RestrictedBroaderGroupsForBuild" : {
-      "Contributors":[
+"Contributors":[
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -305,7 +305,7 @@
       "Readers":[
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -315,7 +315,7 @@
       "Project Collection Valid Users":[
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -325,7 +325,7 @@
       "Project Valid Users":[
         "Manage build queue",
         "Stop builds",
-        "Override build checkIn validation",
+        "Override check-in validation by build",
         "Administer build permissions",
         "Delete build pipeline",
         "Delete builds ",
@@ -368,53 +368,45 @@
     "RestrictedBroaderGroupsForRelease" : {
       "Contributors":[
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Readers":[
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Collection Valid Users":[
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ],
       "Project Valid Users":[
         "Edit release pipeline",
-        "Delete release definition",
         "Edit release stage",
         "Delete release stage",
         "Manage deployments",
         "Administer release permissions",
         "Delete release pipeline",
         "Delete releases",
-        "Delete release stage",
         "Manage release approvers",
         "Manage releases"
       ]
@@ -674,8 +666,8 @@
         "Bypass policies when pushing",
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
-        "Policy exempt for push",
-        "Remove others' locks"
+        "Remove others' locks",
+        "Rename repository"
       ],
       "Readers":[
         "Contribute",
@@ -686,7 +678,6 @@
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
         "Rename repository",
-        "Policy exempt for push",
         "Remove others' locks"
       ],
       "Project Collection Valid Users":[
@@ -698,7 +689,6 @@
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
         "Rename repository",
-        "Policy exempt for push",
         "Remove others' locks"
       ],
       "Project Valid Users":[
@@ -710,7 +700,6 @@
         "Edit policies",
         "Force push (rewrite history, delete branches and tags)",
         "Rename repository",
-        "Policy exempt for push",
         "Remove others' locks"
       ]
     },


### PR DESCRIPTION
Summary: ADO Powershell module has controls related to reviewing broader group access against set of permissions.
These permissions were identified long and there is a need to revisit again to update the permission. The below are the controls we identified to revisit.

ADO_Release_AuthZ_Restrict_Broader_Group_Access
ADO_Build_AuthZ_Restrict_Broader_Group_Access

[Control_Details_AzSK.ADO_1.20.0.csv](https://github.com/dsr-microsoft/DevOps-Security-Scanners/files/14220583/Control_Details_AzSK.ADO_1.20.0.csv)

## Checklist
- [x] I have read the instructions mentioned in [Contribute to Code](/Contributing.md).
- [x] I have read and understood the criteria described under [submitting changes](/Contributing.md#submitting-changes). 
- [x] The title of the PR clearly describes the intent of the PR.
- [x] This PR does not introduce any breaking changes to the code.
