### PR TITLE
Added ADO Powershell controls of Build

### DIFF
--- a/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.Build.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ADO/ADO.Build.json
@@ -323,6 +323,42 @@
         "SkipClassic"
       ],
       "Enabled": true
+    },
+    {
+      "ControlID": "ADO_Build_DP_Dont_Allow_Forked_PublicRepo_Builds_In_PrivateProjects",
+      "Description": "Do not allow builds referring to public repository with forks enabled for private or enterprise project",
+      "Id": "Build300",
+      "ControlSeverity": "High",
+      "Automated": "Yes",
+      "MethodName": "CheckForkedBuildTriggerForPvtProject",
+      "Rationale": "If you build public repositories from GitHub, you must consider your stance on fork builds. Forks are especially dangerous since they come from outside your organization. Secrets can be exposed outside your organization if they are made available to builds of forked repositories.",
+      "Recommendation": "1. Navigate to the build pipeline --> 2. Click on 'Edit' --> 3. Go to 'Triggers' from the three dot menu (present at right top) --> 4. Select repository present under the 'Pull request validation' section --> 5. In the 'Forks' section uncheck 'Build pull requests from forks of this repository'",
+      "Tags": [
+        "SDL",
+        "TCP",
+        "Automated",
+        "DP",
+        "Baseline"
+      ],
+      "Enabled": true
+    },
+    {
+      "ControlID": "ADO_Build_DP_Dont_Allow_Forked_Builds_Run_As_Regular_Builds",
+      "Description": "Do not allow forked builds to run with same permissions as regular builds in public repositories.",
+      "Id": "Build310",
+      "ControlSeverity": "High",
+      "Automated": "Yes",
+      "MethodName": "CheckForkedBuildTriggerWithFullAccessToken",
+      "Rationale": "If you work with public repositories, you must avoid letting builds from forks have same permission as regular builds. Critical resources can be exposed outside your organization if regular build permissions are made available to forked builds.",
+      "Recommendation": "1. Navigate to the build pipeline --> 2. Click on 'Edit' option --> 3. Go to 'Triggers' from the three dot menu (present at right top) --> 4. Select repository present under the 'Pull request validation' section --> 5. In the 'Forks' section uncheck 'Make fork builds have the same permissions as regular builds'",
+      "Tags": [
+        "SDL",
+        "TCP",
+        "Automated",
+        "DP",
+        "Baseline"
+      ],
+      "Enabled": true
     }
   ]
 }

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -78,7 +78,9 @@
           "ADO_Build_AuthZ_Limit_Pipeline_Access",
           "ADO_Build_AuthZ_Restrict_Broader_Group_Access",
           "ADO_Build_DP_Dont_Make_Secrets_Available_To_Forked_Builds",
-          "ADO_Build_DP_Review_Inactive_Build"
+          "ADO_Build_DP_Review_Inactive_Build",
+          "ADO_Build_DP_Dont_Allow_Forked_PublicRepo_Builds_In_PrivateProjects",
+          "ADO_Build_DP_Dont_Allow_Forked_Builds_Run_As_Regular_Builds"
         ]
       },
       {
@@ -919,7 +921,9 @@
         "ADO_Build_SI_Dont_Use_Broadly_Editable_Task_Group",
         "ADO_Build_SI_Dont_Use_Broadly_Editable_Variable_Group",
         "ADO_Build_DP_Dont_Make_Secrets_Available_To_Forked_Builds",
-        "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time"
+        "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time",
+        "ADO_Build_DP_Dont_Allow_Forked_PublicRepo_Builds_In_PrivateProjects",
+        "ADO_Build_DP_Dont_Allow_Forked_Builds_Run_As_Regular_Builds"
       ]
     
     },

--- a/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
+++ b/src/AzSK.ADO/Framework/Configurations/SVT/ControlSettings.json
@@ -295,7 +295,7 @@
         "SolutionName"
     ],
     "RestrictedBroaderGroupsForBuild": {
-
+      
       "Contributors": [
         "Manage build queue",
         "Stop builds",
@@ -339,7 +339,11 @@
     },
     "CheckForInheritedPermissions" : false,
     "RegexForOAuthTokenInYAMLScript" : "\\s*:\\s*\\$\\s*\\(\\s*System\\.AccessToken\\s*\\)",
-    "BranchesToCheckForYAMLScript": ["master","main","develop"]
+    "BranchesToCheckForYAMLScript": ["master","main","develop"],
+    "ProjectVisibilitiesToCheck":[
+      "organization",
+      "private"
+    ]
   },
   "Release": {
     "ReleaseHistoryPeriodInDays": 180,

--- a/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
+++ b/src/AzSK.ADO/Framework/Core/SVT/ADO/ADO.Build.ps1
@@ -1961,7 +1961,7 @@ class Build: ADOSVTBase
     hidden [ControlResult] CheckForkedBuildTrigger([ControlResult] $controlResult) {
         # Start with initial failed status
         $controlResult.VerificationResult = [VerificationResult]::Failed
-        $projectVisibilityCheck = @($this.ControlSettings.Project.ProjectVisibilitiesToCheck)
+        $projectVisibilityCheck = @($this.ControlSettings.Build.ProjectVisibilitiesToCheck)
 
         if ($projectVisibilityCheck.Count -eq 0) {
             $controlResult.AddMessage([VerificationResult]::Error, "Project visibilities to check are not available in control settings");
@@ -2487,7 +2487,7 @@ class Build: ADOSVTBase
     hidden [ControlResult] CheckForkedBuildTriggerForPvtProject([ControlResult] $controlResult) {
         # Start with initial failed status
         $controlResult.VerificationResult = [VerificationResult]::Failed
-        $projectVisibilityCheck = @($this.ControlSettings.Project.ProjectVisibilitiesToCheck)
+        $projectVisibilityCheck = @($this.ControlSettings.Build.ProjectVisibilitiesToCheck)
 
         if ($projectVisibilityCheck.Count -eq 0) {
             $controlResult.AddMessage([VerificationResult]::Error, "Project visibilities to check are not available in control settings.");
@@ -2555,7 +2555,7 @@ class Build: ADOSVTBase
     hidden [ControlResult] CheckForkedBuildTriggerWithFullAccessToken([ControlResult] $controlResult) {
         # Start with initial failed status
         $controlResult.VerificationResult = [VerificationResult]::Failed
-        $projectVisibilityCheck = @($this.ControlSettings.Project.ProjectVisibilitiesToCheck)
+        $projectVisibilityCheck = @($this.ControlSettings.Build.ProjectVisibilitiesToCheck)
 
         if ($projectVisibilityCheck.Count -eq 0) {
             $controlResult.AddMessage([VerificationResult]::Error, "Project visibilities to check are not available in control settings.");

--- a/src/oss-config-preview/1.0.0/ControlSettings.json
+++ b/src/oss-config-preview/1.0.0/ControlSettings.json
@@ -78,7 +78,9 @@
           "ADO_Build_AuthZ_Limit_Pipeline_Access",
           "ADO_Build_AuthZ_Restrict_Broader_Group_Access",
           "ADO_Build_DP_Dont_Make_Secrets_Available_To_Forked_Builds",
-          "ADO_Build_DP_Review_Inactive_Build"
+          "ADO_Build_DP_Review_Inactive_Build",
+          "ADO_Build_DP_Dont_Allow_Forked_PublicRepo_Builds_In_PrivateProjects",
+          "ADO_Build_DP_Dont_Allow_Forked_Builds_Run_As_Regular_Builds"
         ]
       },
       {
@@ -918,7 +920,9 @@
         "ADO_Build_SI_Dont_Use_Broadly_Editable_Task_Group",
         "ADO_Build_SI_Dont_Use_Broadly_Editable_Variable_Group",
         "ADO_Build_DP_Dont_Make_Secrets_Available_To_Forked_Builds",
-        "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time"
+        "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time",
+        "ADO_Build_DP_Dont_Allow_Forked_PublicRepo_Builds_In_PrivateProjects",
+        "ADO_Build_DP_Dont_Allow_Forked_Builds_Run_As_Regular_Builds"
       ]  
 
     },

--- a/src/oss-config/1.0.0/ControlSettings.json
+++ b/src/oss-config/1.0.0/ControlSettings.json
@@ -78,7 +78,9 @@
           "ADO_Build_AuthZ_Limit_Pipeline_Access",
           "ADO_Build_AuthZ_Restrict_Broader_Group_Access",
           "ADO_Build_DP_Dont_Make_Secrets_Available_To_Forked_Builds",
-          "ADO_Build_DP_Review_Inactive_Build"
+          "ADO_Build_DP_Review_Inactive_Build",
+          "ADO_Build_DP_Dont_Allow_Forked_PublicRepo_Builds_In_PrivateProjects",
+          "ADO_Build_DP_Dont_Allow_Forked_Builds_Run_As_Regular_Builds"
         ]
       },
       {
@@ -918,7 +920,9 @@
         "ADO_Build_SI_Dont_Use_Broadly_Editable_Task_Group",
         "ADO_Build_SI_Dont_Use_Broadly_Editable_Variable_Group",
         "ADO_Build_DP_Dont_Make_Secrets_Available_To_Forked_Builds",
-        "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time"
+        "ADO_Build_SI_Review_URL_Variables_Settable_At_Queue_Time",
+        "ADO_Build_DP_Dont_Allow_Forked_PublicRepo_Builds_In_PrivateProjects",
+        "ADO_Build_DP_Dont_Allow_Forked_Builds_Run_As_Regular_Builds"
       ]  
     },
     {


### PR DESCRIPTION
## Description
</br>
 This pull request updates the ADO PowerShell module by making modifications to one existing control and adding two new controls.

## Details
1. Updated Control:
    - Control Name: ADO_Build_DP_Dont_Make_Secrets_Available_To_Forked_Builds
    - Description:  This control ensures that anyone outside from the organization cannot get access to build pipeline secrets that were meant to be internal. Previously this control used to check only build level settings now with the updates it can check project level settings also.
 2. New Control 1:
    - Control Name: ADO_Build_DP_Dont_Allow_Forked_PublicRepo_Builds_In_PrivateProjects
    - Description: This control checks that project does not allow builds referring to public repository with forks enabled for private or enterprise project.
 3. New Control 2:
    - Control Name: ADO_Build_DP_Dont_Allow_Forked_Builds_Run_As_Regular_Builds
    - Description: This control checks that project does not allow forked builds to run with same permissions as regular builds in public repositories.

